### PR TITLE
feat: benchmark protocol (echo latency + throughput)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 
 [features]
 default = []
+benchmark = []
 ble-macos = ["dep:bluest", "dep:objc2", "dep:objc2-core-bluetooth", "dep:objc2-foundation", "dep:dispatch2", "dep:uuid"]
 
 [dependencies]

--- a/src/benchmark/echo.rs
+++ b/src/benchmark/echo.rs
@@ -1,0 +1,179 @@
+//! Echo benchmark: round-trip latency measurement.
+
+use crate::benchmark::types::{EchoRequest, EchoResponse, now_micros, MSG_ECHO_RESPONSE};
+
+/// Result of a single echo measurement.
+#[derive(Clone, Debug)]
+pub struct EchoResult {
+    /// Round-trip time in microseconds.
+    pub rtt_us: u64,
+    /// Sequence number of this probe.
+    pub seq: u32,
+    /// Payload length echoed back.
+    pub payload_len: usize,
+}
+
+/// Aggregate statistics over a set of echo results.
+#[derive(Clone, Debug)]
+pub struct EchoStats {
+    /// Individual results, sorted by sequence number.
+    pub results: Vec<EchoResult>,
+    /// Minimum RTT in microseconds.
+    pub min_us: u64,
+    /// Maximum RTT in microseconds.
+    pub max_us: u64,
+    /// Mean RTT in microseconds.
+    pub mean_us: u64,
+    /// Median RTT in microseconds.
+    pub median_us: u64,
+    /// 95th percentile RTT in microseconds.
+    pub p95_us: u64,
+    /// Number of missing sequences (lost probes).
+    pub loss_count: usize,
+    /// Jitter (mean absolute deviation of RTTs) in microseconds.
+    pub jitter_us: u64,
+}
+
+/// Build an echo request wire frame (msg_type byte + encoded body).
+pub fn build_echo_request_frame(seq: u32, payload: &[u8]) -> Vec<u8> {
+    let req = EchoRequest::new(seq, payload.to_vec());
+    let mut frame = vec![super::types::MSG_ECHO_REQUEST];
+    frame.extend(req.encode());
+    frame
+}
+
+/// Build an echo response wire frame for a received echo request body.
+///
+/// `request_body` is the payload *after* the msg_type byte.
+/// Returns `None` if the request body is malformed.
+pub fn build_echo_response_frame(request_body: &[u8]) -> Option<Vec<u8>> {
+    let req = EchoRequest::decode(request_body)?;
+    let recv_ts = now_micros();
+    let resp = EchoResponse::from_request(&req, recv_ts);
+    let mut frame = vec![MSG_ECHO_RESPONSE];
+    frame.extend(resp.encode());
+    Some(frame)
+}
+
+/// Process a received echo response and compute the RTT.
+///
+/// `response_body` is the payload *after* the msg_type byte.
+/// Returns `None` if the response is malformed.
+pub fn handle_echo_response(response_body: &[u8]) -> Option<EchoResult> {
+    let resp = EchoResponse::decode(response_body)?;
+    let now = now_micros();
+    let rtt_us = now.saturating_sub(resp.send_ts);
+    Some(EchoResult {
+        rtt_us,
+        seq: resp.seq,
+        payload_len: resp.payload.len(),
+    })
+}
+
+/// Compute aggregate statistics from a sorted list of echo results.
+///
+/// `total_expected` is the number of requests sent (to compute loss).
+pub fn compute_echo_stats(results: Vec<EchoResult>, total_expected: usize) -> EchoStats {
+    if results.is_empty() {
+        return EchoStats {
+            results: Vec::new(),
+            min_us: 0,
+            max_us: 0,
+            mean_us: 0,
+            median_us: 0,
+            p95_us: 0,
+            loss_count: total_expected,
+            jitter_us: 0,
+        };
+    }
+
+    let mut rtts: Vec<u64> = results.iter().map(|r| r.rtt_us).collect();
+    rtts.sort();
+
+    let min_us = rtts[0];
+    let max_us = rtts[rtts.len() - 1];
+    let sum: u64 = rtts.iter().sum();
+    let mean_us = sum / rtts.len() as u64;
+
+    let median_us = if rtts.len() % 2 == 1 {
+        rtts[rtts.len() / 2]
+    } else {
+        (rtts[rtts.len() / 2 - 1] + rtts[rtts.len() / 2]) / 2
+    };
+
+    let p95_idx = ((rtts.len() as f64) * 0.95).ceil() as usize;
+    let p95_us = rtts[p95_idx.min(rtts.len()) - 1];
+
+    let loss_count = total_expected.saturating_sub(results.len());
+
+    let jitter_us = if rtts.len() > 1 {
+        let mean = mean_us as i64;
+        let deviation_sum: u64 = rtts
+            .iter()
+            .map(|&r| (r as i64 - mean).unsigned_abs())
+            .sum();
+        deviation_sum / rtts.len() as u64
+    } else {
+        0
+    };
+
+    EchoStats {
+        results,
+        min_us,
+        max_us,
+        mean_us,
+        median_us,
+        p95_us,
+        loss_count,
+        jitter_us,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_and_parse_echo_request() {
+        let frame = build_echo_request_frame(1, &[0xAA, 0xBB]);
+        assert_eq!(frame[0], super::super::types::MSG_ECHO_REQUEST);
+        let body = &frame[1..];
+        let decoded = EchoRequest::decode(body).unwrap();
+        assert_eq!(decoded.seq, 1);
+        assert_eq!(decoded.payload, vec![0xAA, 0xBB]);
+    }
+
+    #[test]
+    fn build_echo_response_from_request() {
+        let req_frame = build_echo_request_frame(42, &[]);
+        let req_body = &req_frame[1..];
+        let resp_frame = build_echo_response_frame(req_body).unwrap();
+        assert_eq!(resp_frame[0], MSG_ECHO_RESPONSE);
+        let resp_body = &resp_frame[1..];
+        let resp = EchoResponse::decode(resp_body).unwrap();
+        assert_eq!(resp.seq, 42);
+    }
+
+    #[test]
+    fn compute_stats_basic() {
+        let results = vec![
+            EchoResult { rtt_us: 100, seq: 0, payload_len: 0 },
+            EchoResult { rtt_us: 200, seq: 1, payload_len: 0 },
+            EchoResult { rtt_us: 300, seq: 2, payload_len: 0 },
+        ];
+        let stats = compute_echo_stats(results, 5);
+        assert_eq!(stats.min_us, 100);
+        assert_eq!(stats.max_us, 300);
+        assert_eq!(stats.mean_us, 200);
+        assert_eq!(stats.median_us, 200);
+        assert_eq!(stats.loss_count, 2);
+        assert!(stats.jitter_us > 0);
+    }
+
+    #[test]
+    fn compute_stats_empty() {
+        let stats = compute_echo_stats(vec![], 10);
+        assert_eq!(stats.loss_count, 10);
+        assert_eq!(stats.min_us, 0);
+    }
+}

--- a/src/benchmark/echo.rs
+++ b/src/benchmark/echo.rs
@@ -1,6 +1,6 @@
 //! Echo benchmark: round-trip latency measurement.
 
-use crate::benchmark::types::{EchoRequest, EchoResponse, now_micros, MSG_ECHO_RESPONSE};
+use crate::benchmark::types::{EchoRequest, EchoResponse, MSG_ECHO_RESPONSE, now_micros};
 
 /// Result of a single echo measurement.
 #[derive(Clone, Debug)]
@@ -108,10 +108,7 @@ pub fn compute_echo_stats(results: Vec<EchoResult>, total_expected: usize) -> Ec
 
     let jitter_us = if rtts.len() > 1 {
         let mean = mean_us as i64;
-        let deviation_sum: u64 = rtts
-            .iter()
-            .map(|&r| (r as i64 - mean).unsigned_abs())
-            .sum();
+        let deviation_sum: u64 = rtts.iter().map(|&r| (r as i64 - mean).unsigned_abs()).sum();
         deviation_sum / rtts.len() as u64
     } else {
         0
@@ -157,9 +154,21 @@ mod tests {
     #[test]
     fn compute_stats_basic() {
         let results = vec![
-            EchoResult { rtt_us: 100, seq: 0, payload_len: 0 },
-            EchoResult { rtt_us: 200, seq: 1, payload_len: 0 },
-            EchoResult { rtt_us: 300, seq: 2, payload_len: 0 },
+            EchoResult {
+                rtt_us: 100,
+                seq: 0,
+                payload_len: 0,
+            },
+            EchoResult {
+                rtt_us: 200,
+                seq: 1,
+                payload_len: 0,
+            },
+            EchoResult {
+                rtt_us: 300,
+                seq: 2,
+                payload_len: 0,
+            },
         ];
         let stats = compute_echo_stats(results, 5);
         assert_eq!(stats.min_us, 100);

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -190,7 +190,7 @@ impl BenchmarkManager {
         }
     }
 
-    const ECHO_RESPONSE_TIMEOUT_MS: u64 = 5000;
+    const ECHO_RESPONSE_TIMEOUT_MS: u64 = 2000;
 
     pub fn poll_echo_sends(&mut self) -> Option<(NodeAddr, Vec<u8>)> {
         if self.pending_echo_sends.is_empty() {

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -262,11 +262,10 @@ impl BenchmarkManager {
         }
     }
 
-    /// Drain all throughput frames that are due based on elapsed time.
+    /// Drain throughput frames that are due based on elapsed time.
     ///
     /// Returns a batch of (peer, frame) pairs to send immediately.
-    /// This allows catching up when the poll interval is slower than
-    /// the target send rate.
+    /// Capped at 2 frames per drain to avoid BLE transport congestion.
     pub fn poll_throughput_sends(&mut self) -> Vec<(NodeAddr, Vec<u8>)> {
         if self.pending_throughput_sends.is_empty() {
             return Vec::new();
@@ -283,7 +282,7 @@ impl BenchmarkManager {
         } else {
             1
         };
-        let count = frames_due.min(self.pending_throughput_sends.len());
+        let count = frames_due.min(2).min(self.pending_throughput_sends.len());
         let mut batch = Vec::with_capacity(count);
         for _ in 0..count {
             if let Some(item) = self.pending_throughput_sends.pop_front() {

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -33,6 +33,7 @@ pub struct BenchmarkManager {
     pending_echo_sends: VecDeque<(NodeAddr, u32, Vec<u8>)>,
     echo_inter_send_delay_ms: u64,
     last_echo_send_time: Option<Instant>,
+    echo_in_flight: bool,
 }
 
 impl BenchmarkManager {
@@ -48,6 +49,7 @@ impl BenchmarkManager {
             pending_echo_sends: VecDeque::new(),
             echo_inter_send_delay_ms: DEFAULT_ECHO_INTER_SEND_DELAY_MS,
             last_echo_send_time: None,
+            echo_in_flight: false,
         }
     }
 
@@ -72,6 +74,7 @@ impl BenchmarkManager {
             }
             MSG_ECHO_RESPONSE => {
                 debug!(peer = ?from, "Benchmark: echo response received");
+                self.echo_in_flight = false;
                 if let Some(result) = echo::handle_echo_response(payload) {
                     self.echo_results.entry(*from).or_default().push(result);
                 }
@@ -181,13 +184,14 @@ impl BenchmarkManager {
         self.expect_echo_probes(peer, count);
         self.echo_results.remove(&peer);
         self.last_echo_send_time = None;
+        self.echo_in_flight = false;
         for seq in 0..count {
             self.pending_echo_sends.push_back((peer, seq, payload.clone()));
         }
     }
 
     pub fn poll_echo_sends(&mut self) -> Option<(NodeAddr, Vec<u8>)> {
-        if self.pending_echo_sends.is_empty() {
+        if self.pending_echo_sends.is_empty() || self.echo_in_flight {
             return None;
         }
         if let Some(last) = self.last_echo_send_time {
@@ -197,6 +201,7 @@ impl BenchmarkManager {
             }
         }
         self.last_echo_send_time = Some(Instant::now());
+        self.echo_in_flight = true;
         let (peer, seq, payload) = self.pending_echo_sends.pop_front()?;
         // Build frame at send time so ts_us reflects actual transmission moment
         let frame = echo::build_echo_request_frame(seq, &payload);

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -6,7 +6,8 @@ pub mod echo;
 pub mod throughput;
 pub mod types;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
+use std::time::Instant;
 
 use crate::NodeAddr;
 use echo::{EchoResult, compute_echo_stats};
@@ -19,6 +20,8 @@ use types::{MSG_ECHO_REQUEST, MSG_ECHO_RESPONSE, MSG_THROUGHPUT_REPORT, MSG_THRO
 
 use tracing::{debug, info, warn};
 
+const DEFAULT_ECHO_INTER_SEND_DELAY_MS: u64 = 100;
+
 pub struct BenchmarkManager {
     active_tests: HashMap<u32, ThroughputTestState>,
     echo_results: HashMap<NodeAddr, Vec<EchoResult>>,
@@ -27,6 +30,9 @@ pub struct BenchmarkManager {
     pending_echo_response: Option<(NodeAddr, Vec<u8>)>,
     pending_throughput_config: Option<(NodeAddr, ThroughputTestConfig)>,
     last_throughput_result: Option<(NodeAddr, ThroughputResult)>,
+    pending_echo_sends: VecDeque<(NodeAddr, Vec<u8>)>,
+    echo_inter_send_delay_ms: u64,
+    last_echo_send_time: Option<Instant>,
 }
 
 impl BenchmarkManager {
@@ -39,6 +45,9 @@ impl BenchmarkManager {
             pending_echo_response: None,
             pending_throughput_config: None,
             last_throughput_result: None,
+            pending_echo_sends: VecDeque::new(),
+            echo_inter_send_delay_ms: DEFAULT_ECHO_INTER_SEND_DELAY_MS,
+            last_echo_send_time: None,
         }
     }
 
@@ -161,6 +170,39 @@ impl BenchmarkManager {
         (0..count)
             .map(|seq| echo::build_echo_request_frame(seq, &payload))
             .collect()
+    }
+
+    pub fn start_echo_test(&mut self, peer: NodeAddr, count: u32, payload_size: usize) {
+        let payload = if payload_size > 0 {
+            vec![0xAB; payload_size]
+        } else {
+            Vec::new()
+        };
+        self.expect_echo_probes(peer, count);
+        self.echo_results.remove(&peer);
+        self.last_echo_send_time = None;
+        for seq in 0..count {
+            let frame = echo::build_echo_request_frame(seq, &payload);
+            self.pending_echo_sends.push_back((peer, frame));
+        }
+    }
+
+    pub fn poll_echo_sends(&mut self) -> Option<(NodeAddr, Vec<u8>)> {
+        if self.pending_echo_sends.is_empty() {
+            return None;
+        }
+        if let Some(last) = self.last_echo_send_time {
+            let elapsed = last.elapsed().as_millis() as u64;
+            if elapsed < self.echo_inter_send_delay_ms {
+                return None;
+            }
+        }
+        self.last_echo_send_time = Some(Instant::now());
+        self.pending_echo_sends.pop_front()
+    }
+
+    pub fn echo_sends_pending(&self) -> bool {
+        !self.pending_echo_sends.is_empty()
     }
 
     pub fn prepare_throughput_test(

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -34,6 +34,9 @@ pub struct BenchmarkManager {
     echo_inter_send_delay_ms: u64,
     last_echo_send_time: Option<Instant>,
     echo_sent_at: Option<Instant>,
+    pending_throughput_sends: VecDeque<(NodeAddr, Vec<u8>)>,
+    throughput_send_interval_ms: u64,
+    last_throughput_send_time: Option<Instant>,
 }
 
 impl BenchmarkManager {
@@ -50,6 +53,9 @@ impl BenchmarkManager {
             echo_inter_send_delay_ms: DEFAULT_ECHO_INTER_SEND_DELAY_MS,
             last_echo_send_time: None,
             echo_sent_at: None,
+            pending_throughput_sends: VecDeque::new(),
+            throughput_send_interval_ms: 100,
+            last_throughput_send_time: None,
         }
     }
 
@@ -222,13 +228,65 @@ impl BenchmarkManager {
         !self.pending_echo_sends.is_empty()
     }
 
+    pub fn start_throughput_sends(
+        &mut self,
+        peer: NodeAddr,
+        test_id: u32,
+        frame_size: u16,
+        rate_bps: u32,
+        duration_secs: u8,
+    ) {
+        let data_len = frame_size as usize;
+        let interval_us = if rate_bps > 0 {
+            ((data_len as u64) * 8 * 1_000_000) / rate_bps as u64
+        } else {
+            1000
+        };
+        let total_frames = (duration_secs as u64 * 1_000_000) / interval_us.max(1);
+
+        self.throughput_send_interval_ms = (interval_us / 1000).max(1) as u64;
+        self.last_throughput_send_time = None;
+        self.pending_throughput_sends.clear();
+
+        if let Some(state) = self.active_tests.get_mut(&test_id) {
+            state.frames_sent = total_frames as u32;
+        }
+
+        for seq in 0..total_frames {
+            let frame = throughput::build_throughput_stream_frame(
+                test_id,
+                seq as u32,
+                data_len,
+            );
+            self.pending_throughput_sends.push_back((peer, frame));
+        }
+    }
+
+    pub fn poll_throughput_sends(&mut self) -> Option<(NodeAddr, Vec<u8>)> {
+        if self.pending_throughput_sends.is_empty() {
+            return None;
+        }
+        if let Some(last) = self.last_throughput_send_time {
+            let elapsed = last.elapsed().as_millis() as u64;
+            if elapsed < self.throughput_send_interval_ms {
+                return None;
+            }
+        }
+        self.last_throughput_send_time = Some(Instant::now());
+        self.pending_throughput_sends.pop_front()
+    }
+
+    pub fn throughput_sends_pending(&self) -> bool {
+        !self.pending_throughput_sends.is_empty()
+    }
+
     pub fn prepare_throughput_test(
         &mut self,
         direction: Direction,
         duration_secs: u8,
         frame_size: u16,
         rate_bps: u32,
-    ) -> (u32, Vec<u8>) {
+    ) -> (u32, ThroughputTestConfig, Vec<u8>) {
         let test_id = self.allocate_test_id();
         let config = ThroughputTestConfig {
             test_id,
@@ -240,7 +298,7 @@ impl BenchmarkManager {
         let frame = build_throughput_request_frame(&config);
         let state = ThroughputTestState::new(test_id);
         self.active_tests.insert(test_id, state);
-        (test_id, frame)
+        (test_id, config, frame)
     }
 
     pub fn active_test_mut(&mut self, test_id: u32) -> Option<&mut ThroughputTestState> {

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -1,0 +1,182 @@
+//! Benchmark module — echo latency and throughput measurement.
+//!
+//! Feature-gated behind `#[cfg(feature = "benchmark")]`.
+
+pub mod echo;
+pub mod throughput;
+pub mod types;
+
+use std::collections::HashMap;
+
+use crate::NodeAddr;
+use echo::{EchoResult, compute_echo_stats};
+use throughput::{
+    Direction, ThroughputResult, ThroughputTestConfig, ThroughputTestState,
+    build_throughput_request_frame, handle_throughput_stream, parse_throughput_report,
+    parse_throughput_request,
+};
+use types::{MSG_ECHO_REQUEST, MSG_ECHO_RESPONSE, MSG_THROUGHPUT_REPORT, MSG_THROUGHPUT_STREAM};
+
+use tracing::{debug, info, warn};
+
+pub struct BenchmarkManager {
+    active_tests: HashMap<u32, ThroughputTestState>,
+    echo_results: HashMap<NodeAddr, Vec<EchoResult>>,
+    echo_expected: HashMap<NodeAddr, u32>,
+    next_test_id: u32,
+    pending_echo_response: Option<(NodeAddr, Vec<u8>)>,
+    pending_throughput_config: Option<(NodeAddr, ThroughputTestConfig)>,
+    last_throughput_result: Option<(NodeAddr, ThroughputResult)>,
+}
+
+impl BenchmarkManager {
+    pub fn new() -> Self {
+        Self {
+            active_tests: HashMap::new(),
+            echo_results: HashMap::new(),
+            echo_expected: HashMap::new(),
+            next_test_id: 1,
+            pending_echo_response: None,
+            pending_throughput_config: None,
+            last_throughput_result: None,
+        }
+    }
+
+    pub fn allocate_test_id(&mut self) -> u32 {
+        let id = self.next_test_id;
+        self.next_test_id += 1;
+        id
+    }
+
+    /// Dispatch an incoming link-layer benchmark message.
+    ///
+    /// `msg_type` is the first byte of the decrypted link payload.
+    /// `payload` is everything after that first byte.
+    pub fn handle_link_message(&mut self, from: &NodeAddr, msg_type: u8, payload: &[u8]) {
+        match msg_type {
+            MSG_ECHO_REQUEST => {
+                debug!(peer = ?from, "Benchmark: echo request received");
+                // Build echo response and store for dispatch layer to send.
+                if let Some(frame) = echo::build_echo_response_frame(payload) {
+                    self.pending_echo_response = Some((*from, frame));
+                }
+            }
+            MSG_ECHO_RESPONSE => {
+                debug!(peer = ?from, "Benchmark: echo response received");
+                if let Some(result) = echo::handle_echo_response(payload) {
+                    self.echo_results.entry(*from).or_default().push(result);
+                }
+            }
+            types::MSG_THROUGHPUT_REQUEST => {
+                if let Some(config) = parse_throughput_request(payload) {
+                    info!(
+                        peer = ?from,
+                        test_id = config.test_id,
+                        direction = ?config.direction,
+                        duration = config.duration_secs,
+                        "Benchmark: throughput request received"
+                    );
+                    let state = ThroughputTestState::new(config.test_id);
+                    self.active_tests.insert(config.test_id, state);
+                    self.pending_throughput_config = Some((*from, config));
+                }
+            }
+            MSG_THROUGHPUT_STREAM => {
+                if let Some((test_id, _, _)) = types::ThroughputStream::decode(payload) {
+                    if let Some(state) = self.active_tests.get_mut(&test_id) {
+                        handle_throughput_stream(state, payload);
+                    }
+                }
+            }
+            MSG_THROUGHPUT_REPORT => {
+                if let Some(result) = parse_throughput_report(payload) {
+                    info!(
+                        peer = ?from,
+                        achieved_bps = result.achieved_bps,
+                        loss_rate = format!("{:.1}%", result.frame_loss_rate * 100.0),
+                        "Benchmark: throughput report received"
+                    );
+                    self.last_throughput_result = Some((*from, result));
+                }
+            }
+            _ => {
+                warn!(msg_type, "Benchmark: unknown benchmark message type");
+            }
+        }
+    }
+
+    pub fn take_echo_response(&mut self) -> Option<(NodeAddr, Vec<u8>)> {
+        self.pending_echo_response.take()
+    }
+
+    pub fn take_throughput_config(&mut self) -> Option<(NodeAddr, ThroughputTestConfig)> {
+        self.pending_throughput_config.take()
+    }
+
+    pub fn take_throughput_result(&mut self) -> Option<(NodeAddr, ThroughputResult)> {
+        self.last_throughput_result.take()
+    }
+
+    pub fn expect_echo_probes(&mut self, peer: NodeAddr, count: u32) {
+        self.echo_expected.insert(peer, count);
+    }
+
+    pub fn take_echo_stats(&mut self, peer: &NodeAddr) -> Option<echo::EchoStats> {
+        let results = self.echo_results.remove(peer)?;
+        let expected = self.echo_expected.remove(peer).unwrap_or(results.len() as u32);
+        Some(compute_echo_stats(results, expected as usize))
+    }
+
+    pub fn prepare_echo_test(
+        &mut self,
+        peer: NodeAddr,
+        count: u32,
+        payload_size: usize,
+    ) -> Vec<Vec<u8>> {
+        let payload = if payload_size > 0 {
+            vec![0xAB; payload_size]
+        } else {
+            Vec::new()
+        };
+        self.expect_echo_probes(peer, count);
+        self.echo_results.remove(&peer);
+        (0..count)
+            .map(|seq| echo::build_echo_request_frame(seq, &payload))
+            .collect()
+    }
+
+    pub fn prepare_throughput_test(
+        &mut self,
+        direction: Direction,
+        duration_secs: u8,
+        frame_size: u16,
+        rate_bps: u32,
+    ) -> (u32, Vec<u8>) {
+        let test_id = self.allocate_test_id();
+        let config = ThroughputTestConfig {
+            test_id,
+            direction,
+            duration_secs,
+            frame_size,
+            rate_bps,
+        };
+        let frame = build_throughput_request_frame(&config);
+        let state = ThroughputTestState::new(test_id);
+        self.active_tests.insert(test_id, state);
+        (test_id, frame)
+    }
+
+    pub fn active_test_mut(&mut self, test_id: u32) -> Option<&mut ThroughputTestState> {
+        self.active_tests.get_mut(&test_id)
+    }
+
+    pub fn remove_test(&mut self, test_id: u32) -> Option<ThroughputTestState> {
+        self.active_tests.remove(&test_id)
+    }
+}
+
+impl Default for BenchmarkManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -33,7 +33,7 @@ pub struct BenchmarkManager {
     pending_echo_sends: VecDeque<(NodeAddr, u32, Vec<u8>)>,
     echo_inter_send_delay_ms: u64,
     last_echo_send_time: Option<Instant>,
-    echo_in_flight: bool,
+    echo_sent_at: Option<Instant>,
 }
 
 impl BenchmarkManager {
@@ -49,7 +49,7 @@ impl BenchmarkManager {
             pending_echo_sends: VecDeque::new(),
             echo_inter_send_delay_ms: DEFAULT_ECHO_INTER_SEND_DELAY_MS,
             last_echo_send_time: None,
-            echo_in_flight: false,
+            echo_sent_at: None,
         }
     }
 
@@ -74,7 +74,7 @@ impl BenchmarkManager {
             }
             MSG_ECHO_RESPONSE => {
                 debug!(peer = ?from, "Benchmark: echo response received");
-                self.echo_in_flight = false;
+                self.echo_sent_at = None;
                 if let Some(result) = echo::handle_echo_response(payload) {
                     self.echo_results.entry(*from).or_default().push(result);
                 }
@@ -184,15 +184,25 @@ impl BenchmarkManager {
         self.expect_echo_probes(peer, count);
         self.echo_results.remove(&peer);
         self.last_echo_send_time = None;
-        self.echo_in_flight = false;
+        self.echo_sent_at = None;
         for seq in 0..count {
             self.pending_echo_sends.push_back((peer, seq, payload.clone()));
         }
     }
 
+    const ECHO_RESPONSE_TIMEOUT_MS: u64 = 5000;
+
     pub fn poll_echo_sends(&mut self) -> Option<(NodeAddr, Vec<u8>)> {
-        if self.pending_echo_sends.is_empty() || self.echo_in_flight {
+        if self.pending_echo_sends.is_empty() {
             return None;
+        }
+        if let Some(sent_at) = self.echo_sent_at {
+            let elapsed = sent_at.elapsed().as_millis() as u64;
+            if elapsed < Self::ECHO_RESPONSE_TIMEOUT_MS {
+                return None;
+            }
+            debug!(elapsed_ms = elapsed, "Benchmark: echo response timed out, sending next");
+            self.echo_sent_at = None;
         }
         if let Some(last) = self.last_echo_send_time {
             let elapsed = last.elapsed().as_millis() as u64;
@@ -201,7 +211,7 @@ impl BenchmarkManager {
             }
         }
         self.last_echo_send_time = Some(Instant::now());
-        self.echo_in_flight = true;
+        self.echo_sent_at = Some(Instant::now());
         let (peer, seq, payload) = self.pending_echo_sends.pop_front()?;
         // Build frame at send time so ts_us reflects actual transmission moment
         let frame = echo::build_echo_request_frame(seq, &payload);

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -30,7 +30,7 @@ pub struct BenchmarkManager {
     pending_echo_response: Option<(NodeAddr, Vec<u8>)>,
     pending_throughput_config: Option<(NodeAddr, ThroughputTestConfig)>,
     last_throughput_result: Option<(NodeAddr, ThroughputResult)>,
-    pending_echo_sends: VecDeque<(NodeAddr, Vec<u8>)>,
+    pending_echo_sends: VecDeque<(NodeAddr, u32, Vec<u8>)>,
     echo_inter_send_delay_ms: u64,
     last_echo_send_time: Option<Instant>,
 }
@@ -182,8 +182,7 @@ impl BenchmarkManager {
         self.echo_results.remove(&peer);
         self.last_echo_send_time = None;
         for seq in 0..count {
-            let frame = echo::build_echo_request_frame(seq, &payload);
-            self.pending_echo_sends.push_back((peer, frame));
+            self.pending_echo_sends.push_back((peer, seq, payload.clone()));
         }
     }
 
@@ -198,7 +197,10 @@ impl BenchmarkManager {
             }
         }
         self.last_echo_send_time = Some(Instant::now());
-        self.pending_echo_sends.pop_front()
+        let (peer, seq, payload) = self.pending_echo_sends.pop_front()?;
+        // Build frame at send time so ts_us reflects actual transmission moment
+        let frame = echo::build_echo_request_frame(seq, &payload);
+        Some((peer, frame))
     }
 
     pub fn echo_sends_pending(&self) -> bool {

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -37,6 +37,7 @@ pub struct BenchmarkManager {
     pending_throughput_sends: VecDeque<(NodeAddr, Vec<u8>)>,
     throughput_send_interval_ms: u64,
     last_throughput_send_time: Option<Instant>,
+    initiator_frames_sent: HashMap<u32, u32>,
 }
 
 impl BenchmarkManager {
@@ -56,6 +57,7 @@ impl BenchmarkManager {
             pending_throughput_sends: VecDeque::new(),
             throughput_send_interval_ms: 100,
             last_throughput_send_time: None,
+            initiator_frames_sent: HashMap::new(),
         }
     }
 
@@ -107,7 +109,15 @@ impl BenchmarkManager {
                 }
             }
             MSG_THROUGHPUT_REPORT => {
-                if let Some(result) = parse_throughput_report(payload) {
+                if let Some(mut result) = parse_throughput_report(payload) {
+                    if let Some(initiator_sent) = self.initiator_frames_sent.remove(&result.test_id) {
+                        result.frame_loss_rate = if initiator_sent > 0 {
+                            1.0 - (result.frames_recv as f64 / initiator_sent as f64)
+                        } else {
+                            0.0
+                        };
+                        result.frames_sent = initiator_sent;
+                    }
                     info!(
                         peer = ?from,
                         achieved_bps = result.achieved_bps,
@@ -251,6 +261,7 @@ impl BenchmarkManager {
         if let Some(state) = self.active_tests.get_mut(&test_id) {
             state.frames_sent = total_frames as u32;
         }
+        self.initiator_frames_sent.insert(test_id, total_frames as u32);
 
         for seq in 0..total_frames {
             let frame = throughput::build_throughput_stream_frame(

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -115,19 +115,18 @@ impl BenchmarkManager {
                     if let Some(state) = self.active_tests.get_mut(&test_id) {
                         handle_throughput_stream(state, payload);
                         if state.is_expired() {
-                            let report_frame =
-                                throughput::build_throughput_report_frame(state);
+                            let report_frame = throughput::build_throughput_report_frame(state);
                             let peer = *from;
                             self.active_tests.remove(&test_id);
-                            self.pending_throughput_report =
-                                Some((peer, report_frame));
+                            self.pending_throughput_report = Some((peer, report_frame));
                         }
                     }
                 }
             }
             MSG_THROUGHPUT_REPORT => {
                 if let Some(mut result) = parse_throughput_report(payload) {
-                    if let Some(initiator_sent) = self.initiator_frames_sent.remove(&result.test_id) {
+                    if let Some(initiator_sent) = self.initiator_frames_sent.remove(&result.test_id)
+                    {
                         result.frame_loss_rate = if initiator_sent > 0 {
                             1.0 - (result.frames_recv as f64 / initiator_sent as f64)
                         } else {
@@ -176,7 +175,10 @@ impl BenchmarkManager {
 
     pub fn take_echo_stats(&mut self, peer: &NodeAddr) -> Option<echo::EchoStats> {
         let results = self.echo_results.remove(peer)?;
-        let expected = self.echo_expected.remove(peer).unwrap_or(results.len() as u32);
+        let expected = self
+            .echo_expected
+            .remove(peer)
+            .unwrap_or(results.len() as u32);
         Some(compute_echo_stats(results, expected as usize))
     }
 
@@ -223,7 +225,8 @@ impl BenchmarkManager {
         self.last_echo_send_time = None;
         self.echo_sent_at = None;
         for seq in 0..count {
-            self.pending_echo_sends.push_back((peer, seq, payload.clone()));
+            self.pending_echo_sends
+                .push_back((peer, seq, payload.clone()));
         }
     }
 
@@ -238,7 +241,10 @@ impl BenchmarkManager {
             if elapsed < Self::ECHO_RESPONSE_TIMEOUT_MS {
                 return None;
             }
-            debug!(elapsed_ms = elapsed, "Benchmark: echo response timed out, sending next");
+            debug!(
+                elapsed_ms = elapsed,
+                "Benchmark: echo response timed out, sending next"
+            );
             self.echo_sent_at = None;
         }
         if let Some(last) = self.last_echo_send_time {
@@ -282,14 +288,11 @@ impl BenchmarkManager {
         if let Some(state) = self.active_tests.get_mut(&test_id) {
             state.frames_sent = total_frames as u32;
         }
-        self.initiator_frames_sent.insert(test_id, total_frames as u32);
+        self.initiator_frames_sent
+            .insert(test_id, total_frames as u32);
 
         for seq in 0..total_frames {
-            let frame = throughput::build_throughput_stream_frame(
-                test_id,
-                seq as u32,
-                data_len,
-            );
+            let frame = throughput::build_throughput_stream_frame(test_id, seq as u32, data_len);
             self.pending_throughput_sends.push_back((peer, frame));
         }
     }

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -29,6 +29,7 @@ pub struct BenchmarkManager {
     next_test_id: u32,
     pending_echo_response: Option<(NodeAddr, Vec<u8>)>,
     pending_throughput_config: Option<(NodeAddr, ThroughputTestConfig)>,
+    pending_throughput_report: Option<(NodeAddr, Vec<u8>)>,
     last_throughput_result: Option<(NodeAddr, ThroughputResult)>,
     pending_echo_sends: VecDeque<(NodeAddr, u32, Vec<u8>)>,
     echo_inter_send_delay_ms: u64,
@@ -49,6 +50,7 @@ impl BenchmarkManager {
             next_test_id: 1,
             pending_echo_response: None,
             pending_throughput_config: None,
+            pending_throughput_report: None,
             last_throughput_result: None,
             pending_echo_sends: VecDeque::new(),
             echo_inter_send_delay_ms: DEFAULT_ECHO_INTER_SEND_DELAY_MS,
@@ -96,7 +98,7 @@ impl BenchmarkManager {
                         duration = config.duration_secs,
                         "Benchmark: throughput request received"
                     );
-                    let state = ThroughputTestState::new(config.test_id);
+                    let state = ThroughputTestState::new(config.test_id, config.duration_secs);
                     self.active_tests.insert(config.test_id, state);
                     self.pending_throughput_config = Some((*from, config));
                 }
@@ -105,6 +107,14 @@ impl BenchmarkManager {
                 if let Some((test_id, _, _)) = types::ThroughputStream::decode(payload) {
                     if let Some(state) = self.active_tests.get_mut(&test_id) {
                         handle_throughput_stream(state, payload);
+                        if state.is_expired() {
+                            let report_frame =
+                                throughput::build_throughput_report_frame(state);
+                            let peer = *from;
+                            self.active_tests.remove(&test_id);
+                            self.pending_throughput_report =
+                                Some((peer, report_frame));
+                        }
                     }
                 }
             }
@@ -139,6 +149,10 @@ impl BenchmarkManager {
 
     pub fn take_throughput_config(&mut self) -> Option<(NodeAddr, ThroughputTestConfig)> {
         self.pending_throughput_config.take()
+    }
+
+    pub fn take_throughput_report(&mut self) -> Option<(NodeAddr, Vec<u8>)> {
+        self.pending_throughput_report.take()
     }
 
     pub fn take_throughput_result(&mut self) -> Option<(NodeAddr, ThroughputResult)> {
@@ -326,7 +340,7 @@ impl BenchmarkManager {
             rate_bps,
         };
         let frame = build_throughput_request_frame(&config);
-        let state = ThroughputTestState::new(test_id);
+        let state = ThroughputTestState::new(test_id, duration_secs);
         self.active_tests.insert(test_id, state);
         (test_id, config, frame)
     }

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -18,6 +18,7 @@ use throughput::{
 };
 use types::{MSG_ECHO_REQUEST, MSG_ECHO_RESPONSE, MSG_THROUGHPUT_REPORT, MSG_THROUGHPUT_STREAM};
 
+use crate::peer_policy::PeerPolicy;
 use tracing::{debug, info, warn};
 
 const DEFAULT_ECHO_INTER_SEND_DELAY_MS: u64 = 100;
@@ -39,6 +40,7 @@ pub struct BenchmarkManager {
     throughput_send_interval_ms: u64,
     last_throughput_send_time: Option<Instant>,
     initiator_frames_sent: HashMap<u32, u32>,
+    peer_policy: PeerPolicy,
 }
 
 impl BenchmarkManager {
@@ -60,6 +62,7 @@ impl BenchmarkManager {
             throughput_send_interval_ms: 100,
             last_throughput_send_time: None,
             initiator_frames_sent: HashMap::new(),
+            peer_policy: PeerPolicy::new(),
         }
     }
 
@@ -74,6 +77,10 @@ impl BenchmarkManager {
     /// `msg_type` is the first byte of the decrypted link payload.
     /// `payload` is everything after that first byte.
     pub fn handle_link_message(&mut self, from: &NodeAddr, msg_type: u8, payload: &[u8]) {
+        if !self.peer_policy.check_frame_rate() {
+            return;
+        }
+
         match msg_type {
             MSG_ECHO_REQUEST => {
                 debug!(peer = ?from, "Benchmark: echo request received");

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -262,18 +262,38 @@ impl BenchmarkManager {
         }
     }
 
-    pub fn poll_throughput_sends(&mut self) -> Option<(NodeAddr, Vec<u8>)> {
+    /// Drain all throughput frames that are due based on elapsed time.
+    ///
+    /// Returns a batch of (peer, frame) pairs to send immediately.
+    /// This allows catching up when the poll interval is slower than
+    /// the target send rate.
+    pub fn poll_throughput_sends(&mut self) -> Vec<(NodeAddr, Vec<u8>)> {
         if self.pending_throughput_sends.is_empty() {
-            return None;
+            return Vec::new();
         }
-        if let Some(last) = self.last_throughput_send_time {
-            let elapsed = last.elapsed().as_millis() as u64;
-            if elapsed < self.throughput_send_interval_ms {
-                return None;
+        let elapsed_ms = self
+            .last_throughput_send_time
+            .map(|t| t.elapsed().as_millis() as u64)
+            .unwrap_or(u64::MAX);
+        if elapsed_ms < self.throughput_send_interval_ms {
+            return Vec::new();
+        }
+        let frames_due = if self.throughput_send_interval_ms > 0 {
+            (elapsed_ms / self.throughput_send_interval_ms).max(1) as usize
+        } else {
+            1
+        };
+        let count = frames_due.min(self.pending_throughput_sends.len());
+        let mut batch = Vec::with_capacity(count);
+        for _ in 0..count {
+            if let Some(item) = self.pending_throughput_sends.pop_front() {
+                batch.push(item);
             }
         }
-        self.last_throughput_send_time = Some(Instant::now());
-        self.pending_throughput_sends.pop_front()
+        if !batch.is_empty() {
+            self.last_throughput_send_time = Some(Instant::now());
+        }
+        batch
     }
 
     pub fn throughput_sends_pending(&self) -> bool {

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -117,6 +117,10 @@ impl BenchmarkManager {
         self.last_throughput_result.take()
     }
 
+    pub fn last_throughput_result(&self) -> Option<&(NodeAddr, ThroughputResult)> {
+        self.last_throughput_result.as_ref()
+    }
+
     pub fn expect_echo_probes(&mut self, peer: NodeAddr, count: u32) {
         self.echo_expected.insert(peer, count);
     }
@@ -125,6 +129,20 @@ impl BenchmarkManager {
         let results = self.echo_results.remove(peer)?;
         let expected = self.echo_expected.remove(peer).unwrap_or(results.len() as u32);
         Some(compute_echo_stats(results, expected as usize))
+    }
+
+    pub fn echo_results_ready(&self, peer: &NodeAddr) -> Option<bool> {
+        let expected = self.echo_expected.get(peer)?;
+        let current = self.echo_results.get(peer).map(|r| r.len()).unwrap_or(0);
+        Some(current >= *expected as usize)
+    }
+
+    pub fn get_echo_stats(&self, peer: &NodeAddr) -> Option<&[EchoResult]> {
+        self.echo_results.get(peer).map(|v| v.as_slice())
+    }
+
+    pub fn echo_expected_count(&self, peer: &NodeAddr) -> Option<u32> {
+        self.echo_expected.get(peer).copied()
     }
 
     pub fn prepare_echo_test(

--- a/src/benchmark/throughput.rs
+++ b/src/benchmark/throughput.rs
@@ -1,9 +1,8 @@
 //! Throughput benchmark: bandwidth measurement.
 
 use crate::benchmark::types::{
-    DIRECTION_UPLOAD, ThroughputReport, ThroughputRequest, ThroughputStream,
-    MSG_THROUGHPUT_REPORT, MSG_THROUGHPUT_REQUEST, MSG_THROUGHPUT_STREAM,
-    now_micros,
+    DIRECTION_UPLOAD, MSG_THROUGHPUT_REPORT, MSG_THROUGHPUT_REQUEST, MSG_THROUGHPUT_STREAM,
+    ThroughputReport, ThroughputRequest, ThroughputStream, now_micros,
 };
 
 /// Throughput test direction.
@@ -105,11 +104,7 @@ pub fn parse_throughput_request(body: &[u8]) -> Option<ThroughputTestConfig> {
 /// Build a throughput stream frame with pseudorandom fill data.
 pub fn build_throughput_stream_frame(test_id: u32, seq: u32, data_len: usize) -> Vec<u8> {
     let data = generate_stream_data(test_id, seq, data_len);
-    let stream = ThroughputStream {
-        test_id,
-        seq,
-        data,
-    };
+    let stream = ThroughputStream { test_id, seq, data };
     let mut frame = vec![MSG_THROUGHPUT_STREAM];
     frame.extend(stream.encode());
     frame
@@ -119,10 +114,7 @@ pub fn build_throughput_stream_frame(test_id: u32, seq: u32, data_len: usize) ->
 ///
 /// Updates the test state with frame/byte counts and detects sequence gaps.
 /// Returns `false` if the frame doesn't match an active test.
-pub fn handle_throughput_stream(
-    state: &mut ThroughputTestState,
-    body: &[u8],
-) -> bool {
+pub fn handle_throughput_stream(state: &mut ThroughputTestState, body: &[u8]) -> bool {
     let (test_id, seq, data) = match ThroughputStream::decode(body) {
         Some(t) => t,
         None => return false,

--- a/src/benchmark/throughput.rs
+++ b/src/benchmark/throughput.rs
@@ -52,6 +52,7 @@ impl ThroughputTestState {
 /// Final result of a throughput test.
 #[derive(Clone, Debug)]
 pub struct ThroughputResult {
+    pub test_id: u32,
     pub achieved_bps: u64,
     pub frame_loss_rate: f64,
     pub total_bytes: u64,
@@ -165,6 +166,7 @@ pub fn parse_throughput_report(body: &[u8]) -> Option<ThroughputResult> {
         0.0
     };
     Some(ThroughputResult {
+        test_id: report.test_id,
         achieved_bps: report.achieved_bps,
         frame_loss_rate,
         total_bytes: report.bytes_recv,
@@ -275,6 +277,7 @@ mod tests {
         let frame = build_throughput_report_frame(&state);
         assert_eq!(frame[0], MSG_THROUGHPUT_REPORT);
         let result = parse_throughput_report(&frame[1..]).unwrap();
+        assert_eq!(result.test_id, 7);
         assert_eq!(result.frames_sent, 100);
         assert_eq!(result.frames_recv, 95);
         assert!((result.frame_loss_rate - 0.05).abs() < 0.001);

--- a/src/benchmark/throughput.rs
+++ b/src/benchmark/throughput.rs
@@ -1,0 +1,282 @@
+//! Throughput benchmark: bandwidth measurement.
+
+use crate::benchmark::types::{
+    DIRECTION_UPLOAD, ThroughputReport, ThroughputRequest, ThroughputStream,
+    MSG_THROUGHPUT_REPORT, MSG_THROUGHPUT_REQUEST, MSG_THROUGHPUT_STREAM,
+    now_micros,
+};
+
+/// Throughput test direction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Direction {
+    Upload,
+    Download,
+}
+
+/// Configuration for a throughput test.
+#[derive(Clone, Debug)]
+pub struct ThroughputTestConfig {
+    pub test_id: u32,
+    pub direction: Direction,
+    pub duration_secs: u8,
+    pub frame_size: u16,
+    pub rate_bps: u32,
+}
+
+/// State tracker for an active throughput test.
+#[derive(Clone, Debug)]
+pub struct ThroughputTestState {
+    pub test_id: u32,
+    pub frames_sent: u32,
+    pub frames_recv: u32,
+    pub bytes_recv: u64,
+    pub start_us: u64,
+    pub expected_seq: u32,
+    pub gap_count: u32,
+}
+
+impl ThroughputTestState {
+    pub fn new(test_id: u32) -> Self {
+        Self {
+            test_id,
+            frames_sent: 0,
+            frames_recv: 0,
+            bytes_recv: 0,
+            start_us: now_micros(),
+            expected_seq: 0,
+            gap_count: 0,
+        }
+    }
+}
+
+/// Final result of a throughput test.
+#[derive(Clone, Debug)]
+pub struct ThroughputResult {
+    pub achieved_bps: u64,
+    pub frame_loss_rate: f64,
+    pub total_bytes: u64,
+    pub duration_us: u64,
+    pub frames_sent: u32,
+    pub frames_recv: u32,
+}
+
+/// Build a throughput request wire frame.
+pub fn build_throughput_request_frame(config: &ThroughputTestConfig) -> Vec<u8> {
+    let req = ThroughputRequest {
+        test_id: config.test_id,
+        direction: match config.direction {
+            Direction::Upload => DIRECTION_UPLOAD,
+            Direction::Download => super::types::DIRECTION_DOWNLOAD,
+        },
+        duration_secs: config.duration_secs,
+        frame_size: config.frame_size,
+        rate_bps: config.rate_bps,
+    };
+    let mut frame = vec![MSG_THROUGHPUT_REQUEST];
+    frame.extend(req.encode());
+    frame
+}
+
+/// Parse a throughput request from a wire body (after msg_type byte).
+pub fn parse_throughput_request(body: &[u8]) -> Option<ThroughputTestConfig> {
+    let req = ThroughputRequest::decode(body)?;
+    Some(ThroughputTestConfig {
+        test_id: req.test_id,
+        direction: if req.direction == DIRECTION_UPLOAD {
+            Direction::Upload
+        } else {
+            Direction::Download
+        },
+        duration_secs: req.duration_secs,
+        frame_size: req.frame_size,
+        rate_bps: req.rate_bps,
+    })
+}
+
+/// Build a throughput stream frame with pseudorandom fill data.
+pub fn build_throughput_stream_frame(test_id: u32, seq: u32, data_len: usize) -> Vec<u8> {
+    let data = generate_stream_data(test_id, seq, data_len);
+    let stream = ThroughputStream {
+        test_id,
+        seq,
+        data,
+    };
+    let mut frame = vec![MSG_THROUGHPUT_STREAM];
+    frame.extend(stream.encode());
+    frame
+}
+
+/// Process a received throughput stream frame.
+///
+/// Updates the test state with frame/byte counts and detects sequence gaps.
+/// Returns `false` if the frame doesn't match an active test.
+pub fn handle_throughput_stream(
+    state: &mut ThroughputTestState,
+    body: &[u8],
+) -> bool {
+    let (test_id, seq, data) = match ThroughputStream::decode(body) {
+        Some(t) => t,
+        None => return false,
+    };
+    if test_id != state.test_id {
+        return false;
+    }
+
+    state.frames_recv += 1;
+    state.bytes_recv += data.len() as u64;
+
+    if seq > state.expected_seq {
+        state.gap_count += seq - state.expected_seq;
+    }
+    state.expected_seq = seq + 1;
+
+    true
+}
+
+/// Build a throughput report wire frame from test state.
+pub fn build_throughput_report_frame(state: &ThroughputTestState) -> Vec<u8> {
+    let now = now_micros();
+    let duration_us = now.saturating_sub(state.start_us);
+    let achieved_bps = if duration_us > 0 {
+        (state.bytes_recv * 8 * 1_000_000) / duration_us
+    } else {
+        0
+    };
+
+    let report = ThroughputReport {
+        test_id: state.test_id,
+        frames_sent: state.frames_sent,
+        frames_recv: state.frames_recv,
+        bytes_recv: state.bytes_recv,
+        duration_us,
+        achieved_bps,
+    };
+    let mut frame = vec![MSG_THROUGHPUT_REPORT];
+    frame.extend(report.encode());
+    frame
+}
+
+/// Parse a throughput report from a wire body and compute final result.
+pub fn parse_throughput_report(body: &[u8]) -> Option<ThroughputResult> {
+    let report = ThroughputReport::decode(body)?;
+    let frame_loss_rate = if report.frames_sent > 0 {
+        1.0 - (report.frames_recv as f64 / report.frames_sent as f64)
+    } else {
+        0.0
+    };
+    Some(ThroughputResult {
+        achieved_bps: report.achieved_bps,
+        frame_loss_rate,
+        total_bytes: report.bytes_recv,
+        duration_us: report.duration_us,
+        frames_sent: report.frames_sent,
+        frames_recv: report.frames_recv,
+    })
+}
+
+/// Generate pseudorandom stream data using a simple LCG seeded from test_id and seq.
+pub fn generate_stream_data(test_id: u32, seq: u32, len: usize) -> Vec<u8> {
+    let mut data = Vec::with_capacity(len);
+    let mut state: u32 = test_id.wrapping_mul(2654435761) ^ seq;
+    for _ in 0..len {
+        state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+        data.push((state >> 24) as u8);
+    }
+    data
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_and_parse_request() {
+        let config = ThroughputTestConfig {
+            test_id: 42,
+            direction: Direction::Upload,
+            duration_secs: 5,
+            frame_size: 256,
+            rate_bps: 40000,
+        };
+        let frame = build_throughput_request_frame(&config);
+        assert_eq!(frame[0], MSG_THROUGHPUT_REQUEST);
+        let parsed = parse_throughput_request(&frame[1..]).unwrap();
+        assert_eq!(parsed.test_id, 42);
+        assert_eq!(parsed.direction, Direction::Upload);
+        assert_eq!(parsed.duration_secs, 5);
+    }
+
+    #[test]
+    fn stream_frame_roundtrip() {
+        let frame = build_throughput_stream_frame(1, 10, 64);
+        assert_eq!(frame[0], MSG_THROUGHPUT_STREAM);
+        let (test_id, seq, data) = ThroughputStream::decode(&frame[1..]).unwrap();
+        assert_eq!(test_id, 1);
+        assert_eq!(seq, 10);
+        assert_eq!(data.len(), 64);
+    }
+
+    #[test]
+    fn handle_stream_tracks_state() {
+        let mut state = ThroughputTestState::new(1);
+        let body = {
+            let frame = build_throughput_stream_frame(1, 0, 32);
+            frame[1..].to_vec()
+        };
+        assert!(handle_throughput_stream(&mut state, &body));
+        assert_eq!(state.frames_recv, 1);
+        assert_eq!(state.bytes_recv, 32);
+        assert_eq!(state.expected_seq, 1);
+    }
+
+    #[test]
+    fn handle_stream_detects_gaps() {
+        let mut state = ThroughputTestState::new(1);
+        state.expected_seq = 0;
+
+        let body = {
+            let frame = build_throughput_stream_frame(1, 5, 16);
+            frame[1..].to_vec()
+        };
+        assert!(handle_throughput_stream(&mut state, &body));
+        assert_eq!(state.gap_count, 5);
+    }
+
+    #[test]
+    fn handle_stream_rejects_wrong_test() {
+        let mut state = ThroughputTestState::new(1);
+        let body = {
+            let frame = build_throughput_stream_frame(99, 0, 16);
+            frame[1..].to_vec()
+        };
+        assert!(!handle_throughput_stream(&mut state, &body));
+    }
+
+    #[test]
+    fn generate_data_deterministic() {
+        let a = generate_stream_data(1, 1, 32);
+        let b = generate_stream_data(1, 1, 32);
+        assert_eq!(a, b);
+        let c = generate_stream_data(2, 1, 32);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn report_roundtrip() {
+        let state = ThroughputTestState {
+            test_id: 7,
+            frames_sent: 100,
+            frames_recv: 95,
+            bytes_recv: 24320,
+            start_us: now_micros() - 5_000_000,
+            expected_seq: 100,
+            gap_count: 5,
+        };
+        let frame = build_throughput_report_frame(&state);
+        assert_eq!(frame[0], MSG_THROUGHPUT_REPORT);
+        let result = parse_throughput_report(&frame[1..]).unwrap();
+        assert_eq!(result.frames_sent, 100);
+        assert_eq!(result.frames_recv, 95);
+        assert!((result.frame_loss_rate - 0.05).abs() < 0.001);
+    }
+}

--- a/src/benchmark/throughput.rs
+++ b/src/benchmark/throughput.rs
@@ -27,6 +27,7 @@ pub struct ThroughputTestConfig {
 #[derive(Clone, Debug)]
 pub struct ThroughputTestState {
     pub test_id: u32,
+    pub duration_secs: u8,
     pub frames_sent: u32,
     pub frames_recv: u32,
     pub bytes_recv: u64,
@@ -36,9 +37,10 @@ pub struct ThroughputTestState {
 }
 
 impl ThroughputTestState {
-    pub fn new(test_id: u32) -> Self {
+    pub fn new(test_id: u32, duration_secs: u8) -> Self {
         Self {
             test_id,
+            duration_secs,
             frames_sent: 0,
             frames_recv: 0,
             bytes_recv: 0,
@@ -46,6 +48,12 @@ impl ThroughputTestState {
             expected_seq: 0,
             gap_count: 0,
         }
+    }
+
+    pub fn is_expired(&self) -> bool {
+        let elapsed_us = now_micros().saturating_sub(self.start_us);
+        let target_us = (self.duration_secs as u64) * 1_000_000;
+        elapsed_us >= target_us
     }
 }
 
@@ -220,7 +228,7 @@ mod tests {
 
     #[test]
     fn handle_stream_tracks_state() {
-        let mut state = ThroughputTestState::new(1);
+        let mut state = ThroughputTestState::new(1, 5);
         let body = {
             let frame = build_throughput_stream_frame(1, 0, 32);
             frame[1..].to_vec()
@@ -233,7 +241,7 @@ mod tests {
 
     #[test]
     fn handle_stream_detects_gaps() {
-        let mut state = ThroughputTestState::new(1);
+        let mut state = ThroughputTestState::new(1, 5);
         state.expected_seq = 0;
 
         let body = {
@@ -246,7 +254,7 @@ mod tests {
 
     #[test]
     fn handle_stream_rejects_wrong_test() {
-        let mut state = ThroughputTestState::new(1);
+        let mut state = ThroughputTestState::new(1, 5);
         let body = {
             let frame = build_throughput_stream_frame(99, 0, 16);
             frame[1..].to_vec()
@@ -267,6 +275,7 @@ mod tests {
     fn report_roundtrip() {
         let state = ThroughputTestState {
             test_id: 7,
+            duration_secs: 5,
             frames_sent: 100,
             frames_recv: 95,
             bytes_recv: 24320,

--- a/src/benchmark/types.rs
+++ b/src/benchmark/types.rs
@@ -1,0 +1,479 @@
+//! Wire types for the FIPS benchmark protocol.
+//!
+//! Encodes and decodes benchmark messages (0xFB-0xFF) matching the
+//! microfips-core wire format exactly. All multi-byte integers are
+//! little-endian.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+// ---------------------------------------------------------------------------
+// Message type constants — must match microfips-core/src/wire.rs
+// ---------------------------------------------------------------------------
+
+/// Echo request — round-trip latency probe.
+pub const MSG_ECHO_REQUEST: u8 = 0xFF;
+/// Echo response — reply to an echo request.
+pub const MSG_ECHO_RESPONSE: u8 = 0xFE;
+/// Throughput request — start a throughput measurement.
+pub const MSG_THROUGHPUT_REQUEST: u8 = 0xFD;
+/// Throughput stream — data frame during a throughput test.
+pub const MSG_THROUGHPUT_STREAM: u8 = 0xFC;
+/// Throughput report — final summary of a throughput test.
+pub const MSG_THROUGHPUT_REPORT: u8 = 0xFB;
+
+// ---------------------------------------------------------------------------
+// Minimum / exact sizes — must match microfips-core/src/wire.rs
+// ---------------------------------------------------------------------------
+
+/// Minimum echo request body: 8 (ts_us) + 4 (seq).
+pub const ECHO_REQUEST_MIN_SIZE: usize = 12;
+/// Minimum echo response body: 8 (send_ts) + 8 (recv_ts) + 4 (seq).
+pub const ECHO_RESPONSE_MIN_SIZE: usize = 20;
+/// Maximum echo payload bytes.
+pub const ECHO_MAX_PAYLOAD: usize = 256;
+/// Exact throughput request body: 4 (test_id) + 1 (direction) + 1 (duration)
+/// + 2 (frame_size) + 4 (rate_bps).
+pub const THROUGHPUT_REQUEST_SIZE: usize = 12;
+/// Minimum throughput stream body: 4 (test_id) + 4 (seq).
+pub const THROUGHPUT_STREAM_MIN_SIZE: usize = 8;
+/// Exact throughput report body: 4 (test_id) + 4 (frames_sent)
+/// + 4 (frames_recv) + 8 (bytes_recv) + 8 (duration_us) + 8 (achieved_bps).
+pub const THROUGHPUT_REPORT_SIZE: usize = 36;
+
+// ---------------------------------------------------------------------------
+// Throughput direction constant
+// ---------------------------------------------------------------------------
+
+/// Upload direction (client sends stream to peer).
+pub const DIRECTION_UPLOAD: u8 = 0;
+/// Download direction (peer sends stream to client).
+pub const DIRECTION_DOWNLOAD: u8 = 1;
+
+// ---------------------------------------------------------------------------
+// EchoRequest
+// ---------------------------------------------------------------------------
+
+/// Echo request: timestamp (micros since epoch), sequence number, payload.
+#[derive(Clone, Debug)]
+pub struct EchoRequest {
+    /// Microseconds since Unix epoch when the request was sent.
+    pub ts_us: u64,
+    /// Monotonically increasing sequence number.
+    pub seq: u32,
+    /// Optional payload bytes.
+    pub payload: Vec<u8>,
+}
+
+impl EchoRequest {
+    /// Build a new echo request with the current timestamp.
+    pub fn new(seq: u32, payload: Vec<u8>) -> Self {
+        Self {
+            ts_us: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_micros() as u64)
+                .unwrap_or(0),
+            seq,
+            payload,
+        }
+    }
+
+    /// Encode to wire format: `[ts_us:u64 LE][seq:u32 LE][payload:variable]`.
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(ECHO_REQUEST_MIN_SIZE + self.payload.len());
+        buf.extend_from_slice(&self.ts_us.to_le_bytes());
+        buf.extend_from_slice(&self.seq.to_le_bytes());
+        buf.extend_from_slice(&self.payload);
+        buf
+    }
+
+    /// Decode from wire format. Returns `None` if the buffer is too short.
+    pub fn decode(body: &[u8]) -> Option<Self> {
+        if body.len() < ECHO_REQUEST_MIN_SIZE {
+            return None;
+        }
+        let ts_us = u64::from_le_bytes(body[0..8].try_into().ok()?);
+        let seq = u32::from_le_bytes(body[8..12].try_into().ok()?);
+        let payload = body[12..].to_vec();
+        Some(Self {
+            ts_us,
+            seq,
+            payload,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// EchoResponse
+// ---------------------------------------------------------------------------
+
+/// Echo response: original send timestamp, receive timestamp, sequence, payload.
+#[derive(Clone, Debug)]
+pub struct EchoResponse {
+    /// Original send timestamp from the request (micros since epoch).
+    pub send_ts: u64,
+    /// Timestamp when the peer received the request (micros since epoch).
+    pub recv_ts: u64,
+    /// Sequence number echoed from the request.
+    pub seq: u32,
+    /// Payload echoed from the request.
+    pub payload: Vec<u8>,
+}
+
+impl EchoResponse {
+    /// Build an echo response from a received request.
+    pub fn from_request(req: &EchoRequest, recv_ts: u64) -> Self {
+        Self {
+            send_ts: req.ts_us,
+            recv_ts,
+            seq: req.seq,
+            payload: req.payload.clone(),
+        }
+    }
+
+    /// Encode to wire format:
+    /// `[send_ts:u64 LE][recv_ts:u64 LE][seq:u32 LE][payload:variable]`.
+    pub fn encode(&self) -> Vec<u8> {
+        let needed = ECHO_RESPONSE_MIN_SIZE + self.payload.len();
+        let mut buf = Vec::with_capacity(needed);
+        buf.extend_from_slice(&self.send_ts.to_le_bytes());
+        buf.extend_from_slice(&self.recv_ts.to_le_bytes());
+        buf.extend_from_slice(&self.seq.to_le_bytes());
+        buf.extend_from_slice(&self.payload);
+        buf
+    }
+
+    /// Encode into a pre-allocated buffer. Returns the number of bytes written.
+    pub fn encode_into(&self, out: &mut [u8]) -> Option<usize> {
+        let needed = ECHO_RESPONSE_MIN_SIZE + self.payload.len();
+        if out.len() < needed || self.payload.len() > ECHO_MAX_PAYLOAD {
+            return None;
+        }
+        out[0..8].copy_from_slice(&self.send_ts.to_le_bytes());
+        out[8..16].copy_from_slice(&self.recv_ts.to_le_bytes());
+        out[16..20].copy_from_slice(&self.seq.to_le_bytes());
+        out[20..needed].copy_from_slice(&self.payload);
+        Some(needed)
+    }
+
+    /// Decode from wire format. Returns `None` if the buffer is too short.
+    pub fn decode(body: &[u8]) -> Option<Self> {
+        if body.len() < ECHO_RESPONSE_MIN_SIZE {
+            return None;
+        }
+        let send_ts = u64::from_le_bytes(body[0..8].try_into().ok()?);
+        let recv_ts = u64::from_le_bytes(body[8..16].try_into().ok()?);
+        let seq = u32::from_le_bytes(body[16..20].try_into().ok()?);
+        let payload = body[20..].to_vec();
+        Some(Self {
+            send_ts,
+            recv_ts,
+            seq,
+            payload,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ThroughputRequest
+// ---------------------------------------------------------------------------
+
+/// Throughput request: start a throughput measurement.
+#[derive(Clone, Debug)]
+pub struct ThroughputRequest {
+    /// Unique test identifier.
+    pub test_id: u32,
+    /// Direction: 0 = upload, 1 = download.
+    pub direction: u8,
+    /// Test duration in seconds.
+    pub duration_secs: u8,
+    /// Frame size in bytes.
+    pub frame_size: u16,
+    /// Target rate in bits per second.
+    pub rate_bps: u32,
+}
+
+impl ThroughputRequest {
+    /// Encode to wire format:
+    /// `[test_id:u32 LE][direction:u8][duration_secs:u8][frame_size:u16 LE][rate_bps:u32 LE]`.
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(THROUGHPUT_REQUEST_SIZE);
+        buf.extend_from_slice(&self.test_id.to_le_bytes());
+        buf.push(self.direction);
+        buf.push(self.duration_secs);
+        buf.extend_from_slice(&self.frame_size.to_le_bytes());
+        buf.extend_from_slice(&self.rate_bps.to_le_bytes());
+        buf
+    }
+
+    /// Decode from wire format. Returns `None` if the buffer is too short.
+    pub fn decode(body: &[u8]) -> Option<Self> {
+        if body.len() < THROUGHPUT_REQUEST_SIZE {
+            return None;
+        }
+        let test_id = u32::from_le_bytes(body[0..4].try_into().ok()?);
+        let direction = body[4];
+        let duration_secs = body[5];
+        let frame_size = u16::from_le_bytes(body[6..8].try_into().ok()?);
+        let rate_bps = u32::from_le_bytes(body[8..12].try_into().ok()?);
+        Some(Self {
+            test_id,
+            direction,
+            duration_secs,
+            frame_size,
+            rate_bps,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ThroughputStream
+// ---------------------------------------------------------------------------
+
+/// Throughput stream: a single data frame during a throughput test.
+#[derive(Clone, Debug)]
+pub struct ThroughputStream {
+    /// Test identifier.
+    pub test_id: u32,
+    /// Frame sequence number.
+    pub seq: u32,
+    /// Data payload.
+    pub data: Vec<u8>,
+}
+
+impl ThroughputStream {
+    /// Encode to wire format: `[test_id:u32 LE][seq:u32 LE][data:variable]`.
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(THROUGHPUT_STREAM_MIN_SIZE + self.data.len());
+        buf.extend_from_slice(&self.test_id.to_le_bytes());
+        buf.extend_from_slice(&self.seq.to_le_bytes());
+        buf.extend_from_slice(&self.data);
+        buf
+    }
+
+    /// Decode from wire format. Returns `None` if the buffer is too short.
+    /// Returns the (test_id, seq, data) tuple.
+    pub fn decode(body: &[u8]) -> Option<(u32, u32, &[u8])> {
+        if body.len() < THROUGHPUT_STREAM_MIN_SIZE {
+            return None;
+        }
+        let test_id = u32::from_le_bytes(body[0..4].try_into().ok()?);
+        let seq = u32::from_le_bytes(body[4..8].try_into().ok()?);
+        Some((test_id, seq, &body[8..]))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ThroughputReport
+// ---------------------------------------------------------------------------
+
+/// Throughput report: final summary of a completed throughput test.
+#[derive(Clone, Debug)]
+pub struct ThroughputReport {
+    /// Test identifier.
+    pub test_id: u32,
+    /// Number of frames sent by the sender.
+    pub frames_sent: u32,
+    /// Number of frames received by the receiver.
+    pub frames_recv: u32,
+    /// Total bytes received.
+    pub bytes_recv: u64,
+    /// Test duration in microseconds.
+    pub duration_us: u64,
+    /// Achieved throughput in bits per second.
+    pub achieved_bps: u64,
+}
+
+impl ThroughputReport {
+    /// Encode to wire format:
+    /// `[test_id:u32 LE][frames_sent:u32 LE][frames_recv:u32 LE]`
+    /// `[bytes_recv:u64 LE][duration_us:u64 LE][achieved_bps:u64 LE]`.
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = vec![0u8; THROUGHPUT_REPORT_SIZE];
+        buf[0..4].copy_from_slice(&self.test_id.to_le_bytes());
+        buf[4..8].copy_from_slice(&self.frames_sent.to_le_bytes());
+        buf[8..12].copy_from_slice(&self.frames_recv.to_le_bytes());
+        buf[12..20].copy_from_slice(&self.bytes_recv.to_le_bytes());
+        buf[20..28].copy_from_slice(&self.duration_us.to_le_bytes());
+        buf[28..36].copy_from_slice(&self.achieved_bps.to_le_bytes());
+        buf
+    }
+
+    /// Encode into a pre-allocated buffer. Returns the number of bytes written.
+    pub fn encode_into(&self, out: &mut [u8]) -> Option<usize> {
+        if out.len() < THROUGHPUT_REPORT_SIZE {
+            return None;
+        }
+        out[0..4].copy_from_slice(&self.test_id.to_le_bytes());
+        out[4..8].copy_from_slice(&self.frames_sent.to_le_bytes());
+        out[8..12].copy_from_slice(&self.frames_recv.to_le_bytes());
+        out[12..20].copy_from_slice(&self.bytes_recv.to_le_bytes());
+        out[20..28].copy_from_slice(&self.duration_us.to_le_bytes());
+        out[28..36].copy_from_slice(&self.achieved_bps.to_le_bytes());
+        Some(THROUGHPUT_REPORT_SIZE)
+    }
+
+    /// Decode from wire format. Returns `None` if the buffer is too short.
+    pub fn decode(body: &[u8]) -> Option<Self> {
+        if body.len() < THROUGHPUT_REPORT_SIZE {
+            return None;
+        }
+        let test_id = u32::from_le_bytes(body[0..4].try_into().ok()?);
+        let frames_sent = u32::from_le_bytes(body[4..8].try_into().ok()?);
+        let frames_recv = u32::from_le_bytes(body[8..12].try_into().ok()?);
+        let bytes_recv = u64::from_le_bytes(body[12..20].try_into().ok()?);
+        let duration_us = u64::from_le_bytes(body[20..28].try_into().ok()?);
+        let achieved_bps = u64::from_le_bytes(body[28..36].try_into().ok()?);
+        Some(Self {
+            test_id,
+            frames_sent,
+            frames_recv,
+            bytes_recv,
+            duration_us,
+            achieved_bps,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Return the current time as microseconds since the Unix epoch.
+pub fn now_micros() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_micros() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn echo_request_roundtrip() {
+        let req = EchoRequest {
+            ts_us: 1_700_000_000_000_000,
+            seq: 42,
+            payload: vec![0xDE, 0xAD, 0xBE, 0xEF],
+        };
+        let encoded = req.encode();
+        let decoded = EchoRequest::decode(&encoded).unwrap();
+        assert_eq!(decoded.ts_us, req.ts_us);
+        assert_eq!(decoded.seq, req.seq);
+        assert_eq!(decoded.payload, req.payload);
+    }
+
+    #[test]
+    fn echo_request_min_payload() {
+        let req = EchoRequest {
+            ts_us: 0,
+            seq: 0,
+            payload: vec![],
+        };
+        let encoded = req.encode();
+        assert_eq!(encoded.len(), ECHO_REQUEST_MIN_SIZE);
+        let decoded = EchoRequest::decode(&encoded).unwrap();
+        assert!(decoded.payload.is_empty());
+    }
+
+    #[test]
+    fn echo_request_too_short() {
+        assert!(EchoRequest::decode(&[0u8; 11]).is_none());
+    }
+
+    #[test]
+    fn echo_response_roundtrip() {
+        let resp = EchoResponse {
+            send_ts: 100,
+            recv_ts: 200,
+            seq: 7,
+            payload: vec![1, 2, 3],
+        };
+        let encoded = resp.encode();
+        let decoded = EchoResponse::decode(&encoded).unwrap();
+        assert_eq!(decoded.send_ts, 100);
+        assert_eq!(decoded.recv_ts, 200);
+        assert_eq!(decoded.seq, 7);
+        assert_eq!(decoded.payload, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn throughput_request_roundtrip() {
+        let req = ThroughputRequest {
+            test_id: 1234,
+            direction: DIRECTION_UPLOAD,
+            duration_secs: 5,
+            frame_size: 256,
+            rate_bps: 40000,
+        };
+        let encoded = req.encode();
+        assert_eq!(encoded.len(), THROUGHPUT_REQUEST_SIZE);
+        let decoded = ThroughputRequest::decode(&encoded).unwrap();
+        assert_eq!(decoded.test_id, 1234);
+        assert_eq!(decoded.direction, DIRECTION_UPLOAD);
+        assert_eq!(decoded.duration_secs, 5);
+        assert_eq!(decoded.frame_size, 256);
+        assert_eq!(decoded.rate_bps, 40000);
+    }
+
+    #[test]
+    fn throughput_stream_roundtrip() {
+        let stream = ThroughputStream {
+            test_id: 99,
+            seq: 1000,
+            data: vec![0xAA; 64],
+        };
+        let encoded = stream.encode();
+        let (test_id, seq, data) = ThroughputStream::decode(&encoded).unwrap();
+        assert_eq!(test_id, 99);
+        assert_eq!(seq, 1000);
+        assert_eq!(data.len(), 64);
+    }
+
+    #[test]
+    fn throughput_report_roundtrip() {
+        let report = ThroughputReport {
+            test_id: 7,
+            frames_sent: 100,
+            frames_recv: 95,
+            bytes_recv: 24320,
+            duration_us: 5_000_000,
+            achieved_bps: 2_000_000,
+        };
+        let encoded = report.encode();
+        assert_eq!(encoded.len(), THROUGHPUT_REPORT_SIZE);
+        let decoded = ThroughputReport::decode(&encoded).unwrap();
+        assert_eq!(decoded.test_id, 7);
+        assert_eq!(decoded.frames_sent, 100);
+        assert_eq!(decoded.frames_recv, 95);
+        assert_eq!(decoded.bytes_recv, 24320);
+        assert_eq!(decoded.duration_us, 5_000_000);
+        assert_eq!(decoded.achieved_bps, 2_000_000);
+    }
+
+    #[test]
+    fn throughput_report_encode_into() {
+        let report = ThroughputReport {
+            test_id: 1,
+            frames_sent: 10,
+            frames_recv: 8,
+            bytes_recv: 2048,
+            duration_us: 1000000,
+            achieved_bps: 16384,
+        };
+        let mut buf = vec![0u8; THROUGHPUT_REPORT_SIZE];
+        let len = report.encode_into(&mut buf).unwrap();
+        assert_eq!(len, THROUGHPUT_REPORT_SIZE);
+        let decoded = ThroughputReport::decode(&buf).unwrap();
+        assert_eq!(decoded.test_id, 1);
+    }
+
+    #[test]
+    fn now_micros_is_reasonable() {
+        let us = now_micros();
+        // Should be after 2020 and before 2100
+        assert!(us > 1577836800000000);
+        assert!(us < 4102444800000000);
+    }
+}

--- a/src/bin/fipsctl.rs
+++ b/src/bin/fipsctl.rs
@@ -448,8 +448,10 @@ fn handle_benchmark(socket_path: &Path, what: &BenchmarkCommands) {
             }
             let wait_secs = (*count as f64 * 0.15).ceil().max(1.0) as u64;
             std::thread::sleep(Duration::from_secs(wait_secs));
-            let query_cmd =
-                build_command("show_benchmark_echo_results", serde_json::json!({"npub": npub}));
+            let query_cmd = build_command(
+                "show_benchmark_echo_results",
+                serde_json::json!({"npub": npub}),
+            );
             match send_request(socket_path, &query_cmd) {
                 Ok(value) => {
                     if *json {
@@ -728,15 +730,30 @@ fn print_throughput_results(value: &serde_json::Value) {
         return;
     }
 
-    let bps = data.get("achieved_bps").and_then(|v| v.as_u64()).unwrap_or(0);
+    let bps = data
+        .get("achieved_bps")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
     let loss = data
         .get("frame_loss_rate")
         .and_then(|v| v.as_f64())
         .unwrap_or(0.0);
-    let bytes = data.get("total_bytes").and_then(|v| v.as_u64()).unwrap_or(0);
-    let dur_us = data.get("duration_us").and_then(|v| v.as_u64()).unwrap_or(0);
-    let sent = data.get("frames_sent").and_then(|v| v.as_u64()).unwrap_or(0);
-    let recv = data.get("frames_recv").and_then(|v| v.as_u64()).unwrap_or(0);
+    let bytes = data
+        .get("total_bytes")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let dur_us = data
+        .get("duration_us")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let sent = data
+        .get("frames_sent")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    let recv = data
+        .get("frames_recv")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
 
     let kbps = bps as f64 / 1000.0;
     let dur_s = dur_us as f64 / 1_000_000.0;
@@ -749,11 +766,7 @@ fn print_throughput_results(value: &serde_json::Value) {
         recv,
         loss * 100.0,
     );
-    println!(
-        "  {} bytes in {:.2}s",
-        bytes,
-        dur_s,
-    );
+    println!("  {} bytes in {:.2}s", bytes, dur_s,);
 }
 
 /// Render the response as a Unicode block sparkline plot.

--- a/src/bin/fipsctl.rs
+++ b/src/bin/fipsctl.rs
@@ -76,6 +76,11 @@ enum Commands {
         #[command(subcommand)]
         what: StatsCommands,
     },
+    /// Run benchmark tests against a peer
+    Benchmark {
+        #[command(subcommand)]
+        what: BenchmarkCommands,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -137,6 +142,46 @@ enum ShowCommands {
 enum AclCommands {
     /// Loaded peer ACL state
     Show,
+}
+
+#[derive(Subcommand, Debug)]
+enum BenchmarkCommands {
+    /// Measure round-trip latency
+    Echo {
+        /// Peer identifier (npub or hostname)
+        #[arg(short, long)]
+        peer: String,
+        /// Number of echo requests to send
+        #[arg(short, long, default_value_t = 10)]
+        count: u32,
+        /// Payload size in bytes (0 for minimal)
+        #[arg(short, long, default_value_t = 0)]
+        payload_size: usize,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+    /// Measure throughput
+    Throughput {
+        /// Peer identifier (npub or hostname)
+        #[arg(short, long)]
+        peer: String,
+        /// Direction: upload or download
+        #[arg(short, long, default_value = "upload")]
+        direction: String,
+        /// Test duration in seconds
+        #[arg(short, long, default_value_t = 5)]
+        duration: u8,
+        /// Frame size in bytes
+        #[arg(short, long, default_value_t = 256)]
+        frame_size: u16,
+        /// Target rate in bits per second
+        #[arg(short, long, default_value_t = 40000)]
+        rate: u32,
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 impl ShowCommands {
@@ -466,6 +511,46 @@ fn main() {
                     params["peer"] = serde_json::json!(resolved);
                 }
                 build_command("show_stats_history", params)
+            }
+        },
+        Commands::Benchmark { what } => match what {
+            BenchmarkCommands::Echo {
+                peer,
+                count,
+                payload_size,
+                json,
+            } => {
+                let npub = resolve_peer(&peer);
+                build_command(
+                    "benchmark_echo",
+                    serde_json::json!({
+                        "npub": npub,
+                        "count": count,
+                        "payload_size": payload_size,
+                        "json": json,
+                    }),
+                )
+            }
+            BenchmarkCommands::Throughput {
+                peer,
+                direction,
+                duration,
+                frame_size,
+                rate,
+                json,
+            } => {
+                let npub = resolve_peer(&peer);
+                build_command(
+                    "benchmark_throughput",
+                    serde_json::json!({
+                        "npub": npub,
+                        "direction": direction,
+                        "duration": duration,
+                        "frame_size": frame_size,
+                        "rate": rate,
+                        "json": json,
+                    }),
+                )
             }
         },
         Commands::Keygen { .. } => unreachable!(),

--- a/src/bin/fipsctl.rs
+++ b/src/bin/fipsctl.rs
@@ -446,7 +446,7 @@ fn handle_benchmark(socket_path: &Path, what: &BenchmarkCommands) {
                     std::process::exit(1);
                 }
             }
-            let wait_secs = (*count as f64 * 0.1).ceil().max(1.0) as u64;
+            let wait_secs = (*count as f64 * 0.15).ceil().max(1.0) as u64;
             std::thread::sleep(Duration::from_secs(wait_secs));
             let query_cmd =
                 build_command("show_benchmark_echo_results", serde_json::json!({"npub": npub}));

--- a/src/bin/fipsctl.rs
+++ b/src/bin/fipsctl.rs
@@ -152,10 +152,10 @@ enum BenchmarkCommands {
         #[arg(short, long)]
         peer: String,
         /// Number of echo requests to send
-        #[arg(short, long, default_value_t = 10)]
+        #[arg(short = 'n', long, default_value_t = 10)]
         count: u32,
         /// Payload size in bytes (0 for minimal)
-        #[arg(short, long, default_value_t = 0)]
+        #[arg(long, default_value_t = 0)]
         payload_size: usize,
         /// Output as JSON
         #[arg(long)]
@@ -170,7 +170,7 @@ enum BenchmarkCommands {
         #[arg(short, long, default_value = "upload")]
         direction: String,
         /// Test duration in seconds
-        #[arg(short, long, default_value_t = 5)]
+        #[arg(short = 'n', long, default_value_t = 5)]
         duration: u8,
         /// Frame size in bytes
         #[arg(short, long, default_value_t = 256)]
@@ -416,6 +416,108 @@ fn resolve_peer(peer: &str) -> String {
     }
 }
 
+fn handle_benchmark(socket_path: &Path, what: &BenchmarkCommands) {
+    match what {
+        BenchmarkCommands::Echo {
+            peer,
+            count,
+            payload_size,
+            json,
+        } => {
+            let npub = resolve_peer(peer);
+            let fire_cmd = build_command(
+                "benchmark_echo",
+                serde_json::json!({
+                    "npub": npub,
+                    "count": count,
+                    "payload_size": payload_size,
+                }),
+            );
+            match send_request(socket_path, &fire_cmd) {
+                Ok(value) => {
+                    let status = value.get("status").and_then(|v| v.as_str()).unwrap_or("");
+                    if status == "error" {
+                        print_response(&value);
+                        return;
+                    }
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    std::process::exit(1);
+                }
+            }
+            let wait_secs = (*count as f64 * 0.1).ceil().max(1.0) as u64;
+            std::thread::sleep(Duration::from_secs(wait_secs));
+            let query_cmd =
+                build_command("benchmark_echo_results", serde_json::json!({"npub": npub}));
+            match send_request(socket_path, &query_cmd) {
+                Ok(value) => {
+                    if *json {
+                        print_response(&value);
+                    } else {
+                        print_echo_results(&value);
+                    }
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        BenchmarkCommands::Throughput {
+            peer,
+            direction,
+            duration,
+            frame_size,
+            rate,
+            json,
+        } => {
+            let npub = resolve_peer(peer);
+            let fire_cmd = build_command(
+                "benchmark_throughput",
+                serde_json::json!({
+                    "npub": npub,
+                    "direction": direction,
+                    "duration": duration,
+                    "frame_size": frame_size,
+                    "rate": rate,
+                }),
+            );
+            match send_request(socket_path, &fire_cmd) {
+                Ok(value) => {
+                    let status = value.get("status").and_then(|v| v.as_str()).unwrap_or("");
+                    if status == "error" {
+                        print_response(&value);
+                        return;
+                    }
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    std::process::exit(1);
+                }
+            }
+            std::thread::sleep(Duration::from_secs(*duration as u64 + 2));
+            let query_cmd = build_command(
+                "benchmark_throughput_results",
+                serde_json::json!({"npub": npub}),
+            );
+            match send_request(socket_path, &query_cmd) {
+                Ok(value) => {
+                    if *json {
+                        print_response(&value);
+                    } else {
+                        print_throughput_results(&value);
+                    }
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+    }
+}
+
 fn main() {
     let cli = Cli::parse();
 
@@ -465,6 +567,12 @@ fn main() {
 
     let socket_path = cli.socket.unwrap_or_else(default_socket_path);
 
+    // Benchmark commands use two-phase fire+query (can't build a single request).
+    if let Commands::Benchmark { what } = &cli.command {
+        handle_benchmark(&socket_path, what);
+        return;
+    }
+
     let request = match &cli.command {
         Commands::Show { what } => build_query(what.command_name()),
         Commands::Acl { what } => build_query(what.command_name()),
@@ -513,46 +621,7 @@ fn main() {
                 build_command("show_stats_history", params)
             }
         },
-        Commands::Benchmark { what } => match what {
-            BenchmarkCommands::Echo {
-                peer,
-                count,
-                payload_size,
-                json,
-            } => {
-                let npub = resolve_peer(&peer);
-                build_command(
-                    "benchmark_echo",
-                    serde_json::json!({
-                        "npub": npub,
-                        "count": count,
-                        "payload_size": payload_size,
-                        "json": json,
-                    }),
-                )
-            }
-            BenchmarkCommands::Throughput {
-                peer,
-                direction,
-                duration,
-                frame_size,
-                rate,
-                json,
-            } => {
-                let npub = resolve_peer(&peer);
-                build_command(
-                    "benchmark_throughput",
-                    serde_json::json!({
-                        "npub": npub,
-                        "direction": direction,
-                        "duration": duration,
-                        "frame_size": frame_size,
-                        "rate": rate,
-                        "json": json,
-                    }),
-                )
-            }
-        },
+        Commands::Benchmark { .. } => unreachable!(),
         Commands::Keygen { .. } => unreachable!(),
     };
 
@@ -581,6 +650,110 @@ fn main() {
             std::process::exit(1);
         }
     }
+}
+
+fn print_echo_results(value: &serde_json::Value) {
+    let status = value
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+
+    if status == "error" {
+        let msg = value
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown error");
+        eprintln!("error: {msg}");
+        std::process::exit(1);
+    }
+
+    let data = value.get("data").unwrap_or(value);
+    let result_status = data.get("status").and_then(|v| v.as_str()).unwrap_or("");
+
+    if result_status == "pending" {
+        println!("Echo test still in progress, try again shortly.");
+        return;
+    }
+
+    let min = data.get("min_us").and_then(|v| v.as_u64()).unwrap_or(0);
+    let max = data.get("max_us").and_then(|v| v.as_u64()).unwrap_or(0);
+    let mean = data.get("mean_us").and_then(|v| v.as_u64()).unwrap_or(0);
+    let median = data.get("median_us").and_then(|v| v.as_u64()).unwrap_or(0);
+    let p95 = data.get("p95_us").and_then(|v| v.as_u64()).unwrap_or(0);
+    let jitter = data.get("jitter_us").and_then(|v| v.as_u64()).unwrap_or(0);
+    let loss = data.get("loss_count").and_then(|v| v.as_u64()).unwrap_or(0);
+
+    let results = data
+        .get("results")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len())
+        .unwrap_or(0);
+
+    println!("Echo Results: {} samples", results);
+    println!(
+        "  min={:.2}ms  max={:.2}ms  mean={:.2}ms  median={:.2}ms",
+        min as f64 / 1000.0,
+        max as f64 / 1000.0,
+        mean as f64 / 1000.0,
+        median as f64 / 1000.0,
+    );
+    println!(
+        "  p95={:.2}ms  jitter={:.2}ms  lost={}",
+        p95 as f64 / 1000.0,
+        jitter as f64 / 1000.0,
+        loss,
+    );
+}
+
+fn print_throughput_results(value: &serde_json::Value) {
+    let status = value
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+
+    if status == "error" {
+        let msg = value
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown error");
+        eprintln!("error: {msg}");
+        std::process::exit(1);
+    }
+
+    let data = value.get("data").unwrap_or(value);
+    let result_status = data.get("status").and_then(|v| v.as_str()).unwrap_or("");
+
+    if result_status == "pending" {
+        println!("Throughput test still in progress, try again shortly.");
+        return;
+    }
+
+    let bps = data.get("achieved_bps").and_then(|v| v.as_u64()).unwrap_or(0);
+    let loss = data
+        .get("frame_loss_rate")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
+    let bytes = data.get("total_bytes").and_then(|v| v.as_u64()).unwrap_or(0);
+    let dur_us = data.get("duration_us").and_then(|v| v.as_u64()).unwrap_or(0);
+    let sent = data.get("frames_sent").and_then(|v| v.as_u64()).unwrap_or(0);
+    let recv = data.get("frames_recv").and_then(|v| v.as_u64()).unwrap_or(0);
+
+    let kbps = bps as f64 / 1000.0;
+    let dur_s = dur_us as f64 / 1_000_000.0;
+
+    println!("Throughput Results:");
+    println!("  {:.2} kbps ({:.2} KB/s)", kbps, bps as f64 / 8000.0);
+    println!(
+        "  {} frames sent, {} received ({:.1}% loss)",
+        sent,
+        recv,
+        loss * 100.0,
+    );
+    println!(
+        "  {} bytes in {:.2}s",
+        bytes,
+        dur_s,
+    );
 }
 
 /// Render the response as a Unicode block sparkline plot.

--- a/src/bin/fipsctl.rs
+++ b/src/bin/fipsctl.rs
@@ -449,7 +449,7 @@ fn handle_benchmark(socket_path: &Path, what: &BenchmarkCommands) {
             let wait_secs = (*count as f64 * 0.1).ceil().max(1.0) as u64;
             std::thread::sleep(Duration::from_secs(wait_secs));
             let query_cmd =
-                build_command("benchmark_echo_results", serde_json::json!({"npub": npub}));
+                build_command("show_benchmark_echo_results", serde_json::json!({"npub": npub}));
             match send_request(socket_path, &query_cmd) {
                 Ok(value) => {
                     if *json {
@@ -498,7 +498,7 @@ fn handle_benchmark(socket_path: &Path, what: &BenchmarkCommands) {
             }
             std::thread::sleep(Duration::from_secs(*duration as u64 + 2));
             let query_cmd = build_command(
-                "benchmark_throughput_results",
+                "show_benchmark_throughput_results",
                 serde_json::json!({"npub": npub}),
             );
             match send_request(socket_path, &query_cmd) {

--- a/src/config/transport.rs
+++ b/src/config/transport.rs
@@ -908,27 +908,32 @@ impl BleConfig {
 
     /// Connection parameter refresh interval in seconds. None = disabled.
     pub fn conn_param_refresh_secs(&self) -> Option<u64> {
-        self.conn_param_refresh_secs.or(DEFAULT_BLE_CONN_PARAM_REFRESH_SECS)
+        self.conn_param_refresh_secs
+            .or(DEFAULT_BLE_CONN_PARAM_REFRESH_SECS)
     }
 
     /// BLE min connection interval in 1.25ms units. Default: 6 (7.5ms).
     pub fn conn_param_min_interval(&self) -> u16 {
-        self.conn_param_min_interval.unwrap_or(DEFAULT_BLE_CONN_PARAM_MIN_INTERVAL)
+        self.conn_param_min_interval
+            .unwrap_or(DEFAULT_BLE_CONN_PARAM_MIN_INTERVAL)
     }
 
     /// BLE max connection interval in 1.25ms units. Default: 20 (25ms).
     pub fn conn_param_max_interval(&self) -> u16 {
-        self.conn_param_max_interval.unwrap_or(DEFAULT_BLE_CONN_PARAM_MAX_INTERVAL)
+        self.conn_param_max_interval
+            .unwrap_or(DEFAULT_BLE_CONN_PARAM_MAX_INTERVAL)
     }
 
     /// BLE peripheral latency. Default: 0.
     pub fn conn_param_latency(&self) -> u16 {
-        self.conn_param_latency.unwrap_or(DEFAULT_BLE_CONN_PARAM_LATENCY)
+        self.conn_param_latency
+            .unwrap_or(DEFAULT_BLE_CONN_PARAM_LATENCY)
     }
 
     /// BLE supervision timeout in 10ms units. Default: 500 (5s).
     pub fn conn_param_timeout(&self) -> u16 {
-        self.conn_param_timeout.unwrap_or(DEFAULT_BLE_CONN_PARAM_TIMEOUT)
+        self.conn_param_timeout
+            .unwrap_or(DEFAULT_BLE_CONN_PARAM_TIMEOUT)
     }
 
     /// SRTT reconnect threshold in milliseconds. None = disabled.
@@ -983,11 +988,13 @@ impl BleConfig {
         }
         if self.conn_param_min_interval == Some(0) {
             self.conn_param_min_interval = None;
-            warnings.push("transports.ble.conn_param_min_interval was 0, reset to default 6".into());
+            warnings
+                .push("transports.ble.conn_param_min_interval was 0, reset to default 6".into());
         }
         if self.conn_param_max_interval == Some(0) {
             self.conn_param_max_interval = None;
-            warnings.push("transports.ble.conn_param_max_interval was 0, reset to default 20".into());
+            warnings
+                .push("transports.ble.conn_param_max_interval was 0, reset to default 20".into());
         }
         if self.conn_param_timeout == Some(0) {
             self.conn_param_timeout = None;
@@ -995,11 +1002,13 @@ impl BleConfig {
         }
         if self.srtt_reconnect_threshold_ms == Some(0) {
             self.srtt_reconnect_threshold_ms = None;
-            warnings.push("transports.ble.srtt_reconnect_threshold_ms was 0, reset to disabled".into());
+            warnings
+                .push("transports.ble.srtt_reconnect_threshold_ms was 0, reset to disabled".into());
         }
         if self.srtt_inflation_threshold == Some(0.0) {
             self.srtt_inflation_threshold = None;
-            warnings.push("transports.ble.srtt_inflation_threshold was 0, reset to disabled".into());
+            warnings
+                .push("transports.ble.srtt_inflation_threshold was 0, reset to disabled".into());
         }
 
         warnings

--- a/src/control/commands.rs
+++ b/src/control/commands.rs
@@ -81,10 +81,7 @@ async fn benchmark_echo(node: &mut Node, params: Option<&Value>) -> Response {
         Some(v) => v,
         None => return Response::error("missing 'npub' parameter"),
     };
-    let count = params
-        .get("count")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(10) as u32;
+    let count = params.get("count").and_then(|v| v.as_u64()).unwrap_or(10) as u32;
     let payload_size = params
         .get("payload_size")
         .and_then(|v| v.as_u64())
@@ -95,7 +92,8 @@ async fn benchmark_echo(node: &mut Node, params: Option<&Value>) -> Response {
         Err(e) => return Response::error(format!("invalid peer npub: {e}")),
     };
 
-    node.benchmark_mut().start_echo_test(peer_addr, count, payload_size);
+    node.benchmark_mut()
+        .start_echo_test(peer_addr, count, payload_size);
 
     Response::ok(serde_json::json!({
         "status": "echo_test_started",
@@ -119,18 +117,12 @@ async fn benchmark_throughput(node: &mut Node, params: Option<&Value>) -> Respon
         .get("direction")
         .and_then(|v| v.as_str())
         .unwrap_or("upload");
-    let duration = params
-        .get("duration")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(5) as u8;
+    let duration = params.get("duration").and_then(|v| v.as_u64()).unwrap_or(5) as u8;
     let frame_size = params
         .get("frame_size")
         .and_then(|v| v.as_u64())
         .unwrap_or(256) as u16;
-    let rate = params
-        .get("rate")
-        .and_then(|v| v.as_u64())
-        .unwrap_or(40000) as u32;
+    let rate = params.get("rate").and_then(|v| v.as_u64()).unwrap_or(40000) as u32;
 
     let peer_addr = match crate::identity::PeerIdentity::from_npub(npub) {
         Ok(id) => *id.node_addr(),
@@ -149,11 +141,7 @@ async fn benchmark_throughput(node: &mut Node, params: Option<&Value>) -> Respon
 
     // Send the ThroughputRequest frame
     if let Err(e) = node
-        .api_send_benchmark_message(
-            &peer_addr,
-            request_frame[0],
-            &request_frame[1..],
-        )
+        .api_send_benchmark_message(&peer_addr, request_frame[0], &request_frame[1..])
         .await
     {
         return Response::error(format!("failed to send throughput request: {e}"));
@@ -168,13 +156,8 @@ async fn benchmark_throughput(node: &mut Node, params: Option<&Value>) -> Respon
             1000
         };
         let total_frames = (duration as u64 * 1_000_000) / interval_us.max(1);
-        node.benchmark_mut().start_throughput_sends(
-            peer_addr,
-            test_id,
-            frame_size,
-            rate,
-            duration,
-        );
+        node.benchmark_mut()
+            .start_throughput_sends(peer_addr, test_id, frame_size, rate, duration);
         total_frames as u32
     } else {
         0

--- a/src/control/commands.rs
+++ b/src/control/commands.rs
@@ -14,9 +14,9 @@ pub async fn dispatch(node: &mut Node, command: &str, params: Option<&Value>) ->
         "connect" => connect(node, params).await,
         "disconnect" => disconnect(node, params),
         #[cfg(feature = "benchmark")]
-        "benchmark_echo" => benchmark_echo(node, params),
+        "benchmark_echo" => benchmark_echo(node, params).await,
         #[cfg(feature = "benchmark")]
-        "benchmark_throughput" => benchmark_throughput(node, params),
+        "benchmark_throughput" => benchmark_throughput(node, params).await,
         _ => Response::error(format!("unknown command: {command}")),
     }
 }
@@ -72,7 +72,7 @@ fn disconnect(node: &mut Node, params: Option<&Value>) -> Response {
 }
 
 #[cfg(feature = "benchmark")]
-fn benchmark_echo(node: &mut Node, params: Option<&Value>) -> Response {
+async fn benchmark_echo(node: &mut Node, params: Option<&Value>) -> Response {
     let Some(params) = params else {
         return Response::error("missing params for benchmark_echo");
     };
@@ -97,17 +97,30 @@ fn benchmark_echo(node: &mut Node, params: Option<&Value>) -> Response {
 
     let frames = node.benchmark_mut().prepare_echo_test(peer_addr, count, payload_size);
 
+    let mut sent = 0u32;
+    for payload in &frames {
+        // payload already includes msg_type byte (0xFF) + body
+        match node
+            .api_send_benchmark_message(&peer_addr, payload[0], &payload[1..])
+            .await
+        {
+            Ok(_) => sent += 1,
+            Err(e) => {
+                debug!(seq = sent, error = %e, "benchmark_echo: send failed");
+            }
+        }
+    }
+
     Response::ok(serde_json::json!({
-        "status": "echo_test_prepared",
+        "status": "echo_test_started",
         "peer": npub,
-        "frame_count": frames.len(),
-        "count": count,
-        "payload_size": payload_size,
+        "sent": sent,
+        "expected": count,
     }))
 }
 
 #[cfg(feature = "benchmark")]
-fn benchmark_throughput(node: &mut Node, params: Option<&Value>) -> Response {
+async fn benchmark_throughput(node: &mut Node, params: Option<&Value>) -> Response {
     let Some(params) = params else {
         return Response::error("missing params for benchmark_throughput");
     };
@@ -133,7 +146,7 @@ fn benchmark_throughput(node: &mut Node, params: Option<&Value>) -> Response {
         .and_then(|v| v.as_u64())
         .unwrap_or(40000) as u32;
 
-    let _peer_addr = match crate::identity::PeerIdentity::from_npub(npub) {
+    let peer_addr = match crate::identity::PeerIdentity::from_npub(npub) {
         Ok(id) => *id.node_addr(),
         Err(e) => return Response::error(format!("invalid peer npub: {e}")),
     };
@@ -144,17 +157,64 @@ fn benchmark_throughput(node: &mut Node, params: Option<&Value>) -> Response {
         _ => return Response::error("direction must be 'upload' or 'download'"),
     };
 
-    let (test_id, _frame) = node
+    let (test_id, request_frame) = node
         .benchmark_mut()
         .prepare_throughput_test(direction, duration, frame_size, rate);
 
+    // Send the ThroughputRequest frame
+    if let Err(e) = node
+        .api_send_benchmark_message(
+            &peer_addr,
+            request_frame[0],
+            &request_frame[1..],
+        )
+        .await
+    {
+        return Response::error(format!("failed to send throughput request: {e}"));
+    }
+
+    // For upload tests, also send the stream frames immediately.
+    // The BLE socket buffers them; the ESP32 counts and sends a report.
+    let mut stream_frames_sent = 0u32;
+    if direction == crate::benchmark::throughput::Direction::Upload {
+        let data_len = frame_size as usize;
+        let interval_us = if rate > 0 {
+            ((data_len as u64) * 8 * 1_000_000) / rate as u64
+        } else {
+            1000
+        };
+        let total_frames = (duration as u64 * 1_000_000) / interval_us.max(1);
+
+        for seq in 0..total_frames {
+            let stream_payload = crate::benchmark::throughput::build_throughput_stream_frame(
+                test_id,
+                seq as u32,
+                data_len,
+            );
+            match node
+                .api_send_benchmark_message(
+                    &peer_addr,
+                    stream_payload[0],
+                    &stream_payload[1..],
+                )
+                .await
+            {
+                Ok(_) => stream_frames_sent += 1,
+                Err(e) => {
+                    debug!(seq, error = %e, "benchmark_throughput: stream send failed");
+                }
+            }
+        }
+    }
+
     Response::ok(serde_json::json!({
-        "status": "throughput_test_prepared",
+        "status": "throughput_test_started",
         "peer": npub,
         "test_id": test_id,
         "direction": direction_str,
         "duration_secs": duration,
         "frame_size": frame_size,
         "rate_bps": rate,
+        "stream_frames_sent": stream_frames_sent,
     }))
 }

--- a/src/control/commands.rs
+++ b/src/control/commands.rs
@@ -1,7 +1,7 @@
 //! Mutating control socket commands.
 //!
-//! Commands that modify node state (connect, disconnect) are handled here,
-//! separate from read-only queries in `queries.rs`.
+//! Commands that modify node state (connect, disconnect, benchmark) are
+//! handled here, separate from read-only queries in `queries.rs`.
 
 use super::protocol::Response;
 use crate::node::Node;
@@ -13,6 +13,10 @@ pub async fn dispatch(node: &mut Node, command: &str, params: Option<&Value>) ->
     match command {
         "connect" => connect(node, params).await,
         "disconnect" => disconnect(node, params),
+        #[cfg(feature = "benchmark")]
+        "benchmark_echo" => benchmark_echo(node, params),
+        #[cfg(feature = "benchmark")]
+        "benchmark_throughput" => benchmark_throughput(node, params),
         _ => Response::error(format!("unknown command: {command}")),
     }
 }
@@ -65,4 +69,92 @@ fn disconnect(node: &mut Node, params: Option<&Value>) -> Response {
         Ok(data) => Response::ok(data),
         Err(msg) => Response::error(msg),
     }
+}
+
+#[cfg(feature = "benchmark")]
+fn benchmark_echo(node: &mut Node, params: Option<&Value>) -> Response {
+    let Some(params) = params else {
+        return Response::error("missing params for benchmark_echo");
+    };
+
+    let npub = match params.get("npub").and_then(|v| v.as_str()) {
+        Some(v) => v,
+        None => return Response::error("missing 'npub' parameter"),
+    };
+    let count = params
+        .get("count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(10) as u32;
+    let payload_size = params
+        .get("payload_size")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize;
+
+    let peer_addr = match crate::identity::PeerIdentity::from_npub(npub) {
+        Ok(id) => *id.node_addr(),
+        Err(e) => return Response::error(format!("invalid peer npub: {e}")),
+    };
+
+    let frames = node.benchmark_mut().prepare_echo_test(peer_addr, count, payload_size);
+
+    Response::ok(serde_json::json!({
+        "status": "echo_test_prepared",
+        "peer": npub,
+        "frame_count": frames.len(),
+        "count": count,
+        "payload_size": payload_size,
+    }))
+}
+
+#[cfg(feature = "benchmark")]
+fn benchmark_throughput(node: &mut Node, params: Option<&Value>) -> Response {
+    let Some(params) = params else {
+        return Response::error("missing params for benchmark_throughput");
+    };
+
+    let npub = match params.get("npub").and_then(|v| v.as_str()) {
+        Some(v) => v,
+        None => return Response::error("missing 'npub' parameter"),
+    };
+    let direction_str = params
+        .get("direction")
+        .and_then(|v| v.as_str())
+        .unwrap_or("upload");
+    let duration = params
+        .get("duration")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(5) as u8;
+    let frame_size = params
+        .get("frame_size")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(256) as u16;
+    let rate = params
+        .get("rate")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(40000) as u32;
+
+    let _peer_addr = match crate::identity::PeerIdentity::from_npub(npub) {
+        Ok(id) => *id.node_addr(),
+        Err(e) => return Response::error(format!("invalid peer npub: {e}")),
+    };
+
+    let direction = match direction_str {
+        "upload" => crate::benchmark::throughput::Direction::Upload,
+        "download" => crate::benchmark::throughput::Direction::Download,
+        _ => return Response::error("direction must be 'upload' or 'download'"),
+    };
+
+    let (test_id, _frame) = node
+        .benchmark_mut()
+        .prepare_throughput_test(direction, duration, frame_size, rate);
+
+    Response::ok(serde_json::json!({
+        "status": "throughput_test_prepared",
+        "peer": npub,
+        "test_id": test_id,
+        "direction": direction_str,
+        "duration_secs": duration,
+        "frame_size": frame_size,
+        "rate_bps": rate,
+    }))
 }

--- a/src/control/commands.rs
+++ b/src/control/commands.rs
@@ -95,26 +95,12 @@ async fn benchmark_echo(node: &mut Node, params: Option<&Value>) -> Response {
         Err(e) => return Response::error(format!("invalid peer npub: {e}")),
     };
 
-    let frames = node.benchmark_mut().prepare_echo_test(peer_addr, count, payload_size);
-
-    let mut sent = 0u32;
-    for payload in &frames {
-        // payload already includes msg_type byte (0xFF) + body
-        match node
-            .api_send_benchmark_message(&peer_addr, payload[0], &payload[1..])
-            .await
-        {
-            Ok(_) => sent += 1,
-            Err(e) => {
-                debug!(seq = sent, error = %e, "benchmark_echo: send failed");
-            }
-        }
-    }
+    node.benchmark_mut().start_echo_test(peer_addr, count, payload_size);
 
     Response::ok(serde_json::json!({
         "status": "echo_test_started",
         "peer": npub,
-        "sent": sent,
+        "queued": count,
         "expected": count,
     }))
 }

--- a/src/control/commands.rs
+++ b/src/control/commands.rs
@@ -143,7 +143,7 @@ async fn benchmark_throughput(node: &mut Node, params: Option<&Value>) -> Respon
         _ => return Response::error("direction must be 'upload' or 'download'"),
     };
 
-    let (test_id, request_frame) = node
+    let (test_id, config, request_frame) = node
         .benchmark_mut()
         .prepare_throughput_test(direction, duration, frame_size, rate);
 
@@ -159,10 +159,8 @@ async fn benchmark_throughput(node: &mut Node, params: Option<&Value>) -> Respon
         return Response::error(format!("failed to send throughput request: {e}"));
     }
 
-    // For upload tests, also send the stream frames immediately.
-    // The BLE socket buffers them; the ESP32 counts and sends a report.
-    let mut stream_frames_sent = 0u32;
-    if direction == crate::benchmark::throughput::Direction::Upload {
+    // For upload tests, queue paced stream frames.
+    let queued_frames: u32 = if direction == crate::benchmark::throughput::Direction::Upload {
         let data_len = frame_size as usize;
         let interval_us = if rate > 0 {
             ((data_len as u64) * 8 * 1_000_000) / rate as u64
@@ -170,28 +168,17 @@ async fn benchmark_throughput(node: &mut Node, params: Option<&Value>) -> Respon
             1000
         };
         let total_frames = (duration as u64 * 1_000_000) / interval_us.max(1);
-
-        for seq in 0..total_frames {
-            let stream_payload = crate::benchmark::throughput::build_throughput_stream_frame(
-                test_id,
-                seq as u32,
-                data_len,
-            );
-            match node
-                .api_send_benchmark_message(
-                    &peer_addr,
-                    stream_payload[0],
-                    &stream_payload[1..],
-                )
-                .await
-            {
-                Ok(_) => stream_frames_sent += 1,
-                Err(e) => {
-                    debug!(seq, error = %e, "benchmark_throughput: stream send failed");
-                }
-            }
-        }
-    }
+        node.benchmark_mut().start_throughput_sends(
+            peer_addr,
+            test_id,
+            frame_size,
+            rate,
+            duration,
+        );
+        total_frames as u32
+    } else {
+        0
+    };
 
     Response::ok(serde_json::json!({
         "status": "throughput_test_started",
@@ -201,6 +188,6 @@ async fn benchmark_throughput(node: &mut Node, params: Option<&Value>) -> Respon
         "duration_secs": duration,
         "frame_size": frame_size,
         "rate_bps": rate,
-        "stream_frames_sent": stream_frames_sent,
+        "queued_stream_frames": queued_frames,
     }))
 }

--- a/src/control/queries.rs
+++ b/src/control/queries.rs
@@ -1209,9 +1209,9 @@ pub fn dispatch(node: &Node, command: &str, params: Option<&Value>) -> super::pr
         "show_stats_peers" => super::protocol::Response::ok(show_stats_peers(node)),
         "show_stats_history_all_peers" => show_stats_history_all_peers(node, params),
         #[cfg(feature = "benchmark")]
-        "benchmark_echo_results" => benchmark_echo_results(node, params),
+        "show_benchmark_echo_results" => benchmark_echo_results(node, params),
         #[cfg(feature = "benchmark")]
-        "benchmark_throughput_results" => benchmark_throughput_results(node, params),
+        "show_benchmark_throughput_results" => benchmark_throughput_results(node, params),
         _ => super::protocol::Response::error(format!("unknown command: {}", command)),
     }
 }

--- a/src/control/queries.rs
+++ b/src/control/queries.rs
@@ -1135,10 +1135,8 @@ fn benchmark_echo_results(node: &Node, params: Option<&Value>) -> super::protoco
                     })
                 })
                 .collect();
-            let computed = crate::benchmark::echo::compute_echo_stats(
-                results.to_vec(),
-                exp as usize,
-            );
+            let computed =
+                crate::benchmark::echo::compute_echo_stats(results.to_vec(), exp as usize);
             Response::ok(json!({
                 "results": results_vec,
                 "min_us": computed.min_us,

--- a/src/control/queries.rs
+++ b/src/control/queries.rs
@@ -1104,6 +1104,89 @@ pub fn show_stats_history_all_peers(
     }))
 }
 
+#[cfg(feature = "benchmark")]
+fn benchmark_echo_results(node: &Node, params: Option<&Value>) -> super::protocol::Response {
+    use super::protocol::Response;
+    let Some(params) = params else {
+        return Response::error("missing params for benchmark_echo_results");
+    };
+    let npub = match params.get("npub").and_then(|v| v.as_str()) {
+        Some(v) => v,
+        None => return Response::error("missing 'npub' parameter"),
+    };
+    let peer_addr = match PeerIdentity::from_npub(npub) {
+        Ok(id) => *id.node_addr(),
+        Err(e) => return Response::error(format!("invalid peer npub: {e}")),
+    };
+
+    let bm = node.benchmark();
+    match (bm.get_echo_stats(&peer_addr), bm.echo_expected_count(&peer_addr)) {
+        (Some(results), Some(expected)) => {
+            let results_vec: Vec<Value> = results
+                .iter()
+                .map(|r| {
+                    json!({
+                        "rtt_us": r.rtt_us,
+                        "seq": r.seq,
+                        "payload_len": r.payload_len,
+                    })
+                })
+                .collect();
+            let stats = crate::benchmark::echo::compute_echo_stats(
+                results.to_vec(),
+                expected as usize,
+            );
+            Response::ok(json!({
+                "results": results_vec,
+                "min_us": stats.min_us,
+                "max_us": stats.max_us,
+                "mean_us": stats.mean_us,
+                "median_us": stats.median_us,
+                "p95_us": stats.p95_us,
+                "loss_count": stats.loss_count,
+                "jitter_us": stats.jitter_us,
+            }))
+        }
+        _ => Response::ok(json!({
+            "status": "pending",
+            "peer": npub,
+        })),
+    }
+}
+
+#[cfg(feature = "benchmark")]
+fn benchmark_throughput_results(node: &Node, params: Option<&Value>) -> super::protocol::Response {
+    use super::protocol::Response;
+    let Some(params) = params else {
+        return Response::error("missing params for benchmark_throughput_results");
+    };
+    let npub = match params.get("npub").and_then(|v| v.as_str()) {
+        Some(v) => v,
+        None => return Response::error("missing 'npub' parameter"),
+    };
+    let _peer_addr = match PeerIdentity::from_npub(npub) {
+        Ok(id) => *id.node_addr(),
+        Err(e) => return Response::error(format!("invalid peer npub: {e}")),
+    };
+
+    match node.benchmark().last_throughput_result() {
+        Some((peer, result)) => Response::ok(json!({
+            "status": "complete",
+            "peer": hex::encode(peer.as_bytes()),
+            "achieved_bps": result.achieved_bps,
+            "frame_loss_rate": result.frame_loss_rate,
+            "total_bytes": result.total_bytes,
+            "duration_us": result.duration_us,
+            "frames_sent": result.frames_sent,
+            "frames_recv": result.frames_recv,
+        })),
+        None => Response::ok(json!({
+            "status": "pending",
+            "peer": npub,
+        })),
+    }
+}
+
 /// Dispatch a command string to the appropriate query function.
 pub fn dispatch(node: &Node, command: &str, params: Option<&Value>) -> super::protocol::Response {
     match command {
@@ -1125,6 +1208,10 @@ pub fn dispatch(node: &Node, command: &str, params: Option<&Value>) -> super::pr
         "show_stats_all_history" => show_stats_all_history(node, params),
         "show_stats_peers" => super::protocol::Response::ok(show_stats_peers(node)),
         "show_stats_history_all_peers" => show_stats_history_all_peers(node, params),
+        #[cfg(feature = "benchmark")]
+        "benchmark_echo_results" => benchmark_echo_results(node, params),
+        #[cfg(feature = "benchmark")]
+        "benchmark_throughput_results" => benchmark_throughput_results(node, params),
         _ => super::protocol::Response::error(format!("unknown command: {}", command)),
     }
 }

--- a/src/control/queries.rs
+++ b/src/control/queries.rs
@@ -1120,8 +1120,11 @@ fn benchmark_echo_results(node: &Node, params: Option<&Value>) -> super::protoco
     };
 
     let bm = node.benchmark();
-    match (bm.get_echo_stats(&peer_addr), bm.echo_expected_count(&peer_addr)) {
-        (Some(results), Some(expected)) => {
+    let stats = bm.get_echo_stats(&peer_addr);
+    let expected = bm.echo_expected_count(&peer_addr);
+
+    match (stats, expected) {
+        (Some(results), Some(exp)) => {
             let results_vec: Vec<Value> = results
                 .iter()
                 .map(|r| {
@@ -1132,21 +1135,25 @@ fn benchmark_echo_results(node: &Node, params: Option<&Value>) -> super::protoco
                     })
                 })
                 .collect();
-            let stats = crate::benchmark::echo::compute_echo_stats(
+            let computed = crate::benchmark::echo::compute_echo_stats(
                 results.to_vec(),
-                expected as usize,
+                exp as usize,
             );
             Response::ok(json!({
                 "results": results_vec,
-                "min_us": stats.min_us,
-                "max_us": stats.max_us,
-                "mean_us": stats.mean_us,
-                "median_us": stats.median_us,
-                "p95_us": stats.p95_us,
-                "loss_count": stats.loss_count,
-                "jitter_us": stats.jitter_us,
+                "min_us": computed.min_us,
+                "max_us": computed.max_us,
+                "mean_us": computed.mean_us,
+                "median_us": computed.median_us,
+                "p95_us": computed.p95_us,
+                "loss_count": computed.loss_count,
+                "jitter_us": computed.jitter_us,
             }))
         }
+        (None, None) => Response::ok(json!({
+            "status": "no_test",
+            "peer": npub,
+        })),
         _ => Response::ok(json!({
             "status": "pending",
             "peer": npub,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod mmp;
 pub mod node;
 pub mod noise;
 pub mod peer;
+pub mod peer_policy;
 pub mod protocol;
 pub mod transport;
 pub mod tree;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@ pub mod upper;
 pub mod utils;
 pub mod version;
 
+#[cfg(feature = "benchmark")]
+pub mod benchmark;
+
 // Re-export identity types
 pub use identity::{
     AuthChallenge, AuthResponse, FipsAddress, Identity, IdentityError, NodeAddr, PeerIdentity,

--- a/src/mmp/metrics.rs
+++ b/src/mmp/metrics.rs
@@ -306,11 +306,7 @@ impl MmpMetrics {
         }
         let srtt = self.srtt_ms()?;
         let min = self.min_rtt_ms()?;
-        if min > 0.0 {
-            Some(srtt / min)
-        } else {
-            None
-        }
+        if min > 0.0 { Some(srtt / min) } else { None }
     }
 
     /// Current loss rate (0.0 = no loss, 1.0 = total loss).

--- a/src/node/handlers/dispatch.rs
+++ b/src/node/handlers/dispatch.rs
@@ -59,6 +59,10 @@ impl Node {
                 // Heartbeat — no-op, last_recv_time already updated by record_recv()
                 trace!(peer = %self.peer_display_name(from), "Received heartbeat");
             }
+            #[cfg(feature = "benchmark")]
+            0xFF | 0xFE | 0xFD | 0xFC | 0xFB => {
+                self.benchmark.handle_link_message(from, msg_type, payload);
+            }
             _ => {
                 debug!(msg_type = msg_type, "Unknown link message type");
             }

--- a/src/node/handlers/encrypted.rs
+++ b/src/node/handlers/encrypted.rs
@@ -178,6 +178,21 @@ impl Node {
         // Dispatch to link message handler
         self.dispatch_link_message(&node_addr, link_message, ce_flag)
             .await;
+
+        // Drain any pending benchmark responses (echo reply, throughput report)
+        #[cfg(feature = "benchmark")]
+        {
+            if let Some((peer, frame)) = self.benchmark_mut().take_echo_response() {
+                let msg_type = frame[0];
+                let body = &frame[1..];
+                let _ = self.api_send_benchmark_message(&peer, msg_type, body).await;
+            }
+            if let Some((peer, frame)) = self.benchmark_mut().take_throughput_report() {
+                let msg_type = frame[0];
+                let body = &frame[1..];
+                let _ = self.api_send_benchmark_message(&peer, msg_type, body).await;
+            }
+        }
     }
 
     /// Log a decryption failure with replay suppression.

--- a/src/node/handlers/handshake.rs
+++ b/src/node/handlers/handshake.rs
@@ -375,7 +375,7 @@ impl Node {
                     if let Some(msg2) = existing_peer.handshake_msg2().map(|m| m.to_vec())
                         && let Some(transport) = self.transports.get(&packet.transport_id)
                     {
-                            match transport.send_urgent(&packet.remote_addr, &msg2).await {
+                        match transport.send_urgent(&packet.remote_addr, &msg2).await {
                             Ok(_) => debug!(
                                 peer = %self.peer_display_name(&peer_node_addr),
                                 "Resent msg2 for duplicate msg1 (same epoch)"
@@ -444,7 +444,7 @@ impl Node {
         }
 
         if let Some(transport) = self.transports.get(&packet.transport_id) {
-                            match transport.send_urgent(&packet.remote_addr, &wire_msg2).await {
+            match transport.send_urgent(&packet.remote_addr, &wire_msg2).await {
                 Ok(bytes) => {
                     debug!(
                         link_id = %link_id,
@@ -478,7 +478,10 @@ impl Node {
         match self.promote_connection(link_id, peer_identity, packet.timestamp_ms) {
             Ok(result) => {
                 match result {
-                    PromotionResult::Promoted { node_addr, cancelled_links } => {
+                    PromotionResult::Promoted {
+                        node_addr,
+                        cancelled_links,
+                    } => {
                         if let Some(peer) = self.peers.get_mut(&node_addr) {
                             peer.set_handshake_msg2(wire_msg2.clone());
                         }
@@ -639,7 +642,12 @@ impl Node {
                     match peer.complete_rekey_msg2(noise_msg2) {
                         Ok(session) => {
                             let our_index = peer.rekey_our_index().unwrap_or(header.receiver_idx);
-                            peer.set_pending_session(session, our_index, header.sender_idx, Self::now_ms());
+                            peer.set_pending_session(
+                                session,
+                                our_index,
+                                header.sender_idx,
+                                Self::now_ms(),
+                            );
 
                             if let Some(transport_id) = peer.transport_id() {
                                 self.peers_by_index
@@ -872,7 +880,10 @@ impl Node {
                 self.pending_outbound.remove(&key);
 
                 match result {
-                    PromotionResult::Promoted { node_addr, cancelled_links } => {
+                    PromotionResult::Promoted {
+                        node_addr,
+                        cancelled_links,
+                    } => {
                         for cancelled_link_id in &cancelled_links {
                             debug!(
                                 peer = %self.peer_display_name(&node_addr),
@@ -1055,7 +1066,9 @@ impl Node {
                 self.retry_pending.remove(&peer_node_addr);
                 self.register_identity(peer_node_addr, verified_identity.pubkey_full());
 
-                let transport_name = self.transports.get(&transport_id)
+                let transport_name = self
+                    .transports
+                    .get(&transport_id)
                     .map(|t| t.transport_type().name)
                     .unwrap_or("unknown");
                 self.store_discovered_peer_config(
@@ -1116,7 +1129,9 @@ impl Node {
                         return None;
                     }
                     if let Some(pending_conn) = self.connections.get(&pending_link_id) {
-                        if let (Some(tid), Some(idx)) = (pending_conn.transport_id(), pending_conn.our_index()) {
+                        if let (Some(tid), Some(idx)) =
+                            (pending_conn.transport_id(), pending_conn.our_index())
+                        {
                             self.pending_outbound.remove(&(tid, idx.as_u32()));
                         }
                         if let Some(idx) = pending_conn.our_index() {
@@ -1181,7 +1196,9 @@ impl Node {
             self.retry_pending.remove(&peer_node_addr);
             self.register_identity(peer_node_addr, verified_identity.pubkey_full());
 
-            let transport_name = self.transports.get(&transport_id)
+            let transport_name = self
+                .transports
+                .get(&transport_id)
                 .map(|t| t.transport_type().name)
                 .unwrap_or("unknown");
             self.store_discovered_peer_config(
@@ -1199,7 +1216,10 @@ impl Node {
                 "Connection promoted to active peer"
             );
 
-            Ok(PromotionResult::Promoted { node_addr: peer_node_addr, cancelled_links })
+            Ok(PromotionResult::Promoted {
+                node_addr: peer_node_addr,
+                cancelled_links,
+            })
         }
     }
 }

--- a/src/node/handlers/mmp.rs
+++ b/src/node/handlers/mmp.rs
@@ -159,13 +159,17 @@ impl Node {
             if our_timestamp_ms > echo_ms + dwell_ms {
                 let rtt_ms = our_timestamp_ms - echo_ms - dwell_ms;
                 let srtt_ms = mmp.metrics.srtt_ms().unwrap_or(0.0);
-                ble_log("mmp_rtt_sample", &peer_name, &[
-                    ("our_ts", &our_timestamp_ms.to_string()),
-                    ("echo_ts", &echo_ms.to_string()),
-                    ("dwell_ms", &dwell_ms.to_string()),
-                    ("rtt_ms", &rtt_ms.to_string()),
-                    ("srtt_ms", &format!("{:.1}", srtt_ms)),
-                ]);
+                ble_log(
+                    "mmp_rtt_sample",
+                    &peer_name,
+                    &[
+                        ("our_ts", &our_timestamp_ms.to_string()),
+                        ("echo_ts", &echo_ms.to_string()),
+                        ("dwell_ms", &dwell_ms.to_string()),
+                        ("rtt_ms", &rtt_ms.to_string()),
+                        ("srtt_ms", &format!("{:.1}", srtt_ms)),
+                    ],
+                );
             }
         }
 
@@ -229,29 +233,42 @@ impl Node {
         // Reference: RFC 6298 SRTT is per-path; a new BLE channel constitutes a new path.
         // QUIC (RFC 9002 §5.3) explicitly resets RTT estimator on path migration.
         if let Some(srtt_ms) = ble_srtt_ms {
-            let inflation_ratio = self.peers.get(from)
+            let inflation_ratio = self
+                .peers
+                .get(from)
                 .and_then(|p| p.mmp())
                 .and_then(|mmp| mmp.metrics.inflation_ratio());
             let exceeded = self.config.transports.ble.iter().find_map(|(_, cfg)| {
-                let abs = cfg.srtt_reconnect_threshold_ms()
+                let abs = cfg
+                    .srtt_reconnect_threshold_ms()
                     .filter(|&threshold| srtt_ms > threshold as f64);
-                let ratio = cfg.srtt_inflation_threshold()
+                let ratio = cfg
+                    .srtt_inflation_threshold()
                     .zip(inflation_ratio)
                     .filter(|&(threshold, ratio)| ratio > threshold);
                 abs.or(ratio.map(|_| 0)) // 0 = ratio-based trigger (for logging)
             });
             if exceeded.is_some() {
-                let min_rtt_str = self.peers.get(from)
+                let min_rtt_str = self
+                    .peers
+                    .get(from)
                     .and_then(|p| p.mmp())
                     .and_then(|mmp| mmp.metrics.min_rtt_ms())
                     .map(|v| format!("{:.1}", v))
                     .unwrap_or_else(|| "n/a".to_string());
-                ble_log("srtt_reconnect", &peer_name, &[
-                    ("srtt_ms", &format!("{:.1}", srtt_ms)),
-                    ("min_rtt_ms", &min_rtt_str),
-                    ("threshold_ms", &format!("{}", exceeded.unwrap())),
-                    ("inflation_ratio", &format!("{:.1}", inflation_ratio.unwrap_or(0.0))),
-                ]);
+                ble_log(
+                    "srtt_reconnect",
+                    &peer_name,
+                    &[
+                        ("srtt_ms", &format!("{:.1}", srtt_ms)),
+                        ("min_rtt_ms", &min_rtt_str),
+                        ("threshold_ms", &format!("{}", exceeded.unwrap())),
+                        (
+                            "inflation_ratio",
+                            &format!("{:.1}", inflation_ratio.unwrap_or(0.0)),
+                        ),
+                    ],
+                );
                 warn!(
                     peer = %peer_name,
                     srtt_ms = format!("{:.1}", srtt_ms),
@@ -265,7 +282,11 @@ impl Node {
                     .map(|d| d.as_millis() as u64)
                     .unwrap_or(0);
                 // Cooldown guard: skip reconnect if last one was too recent.
-                let cooldown_ms = self.config.transports.ble.iter()
+                let cooldown_ms = self
+                    .config
+                    .transports
+                    .ble
+                    .iter()
                     .find_map(|(_, cfg)| {
                         let secs = cfg.proactive_reconnect_cooldown_secs();
                         Some(secs * 1000)
@@ -274,10 +295,14 @@ impl Node {
                 if let Some(&last_ms) = self.last_proactive_reconnect_ms.get(&addr) {
                     let elapsed = now_ms.saturating_sub(last_ms);
                     if elapsed < cooldown_ms {
-                        ble_log("srtt_reconnect_cooldown", &peer_name, &[
-                            ("elapsed_secs", &format!("{}", elapsed / 1000)),
-                            ("cooldown_secs", &format!("{}", cooldown_ms / 1000)),
-                        ]);
+                        ble_log(
+                            "srtt_reconnect_cooldown",
+                            &peer_name,
+                            &[
+                                ("elapsed_secs", &format!("{}", elapsed / 1000)),
+                                ("cooldown_secs", &format!("{}", cooldown_ms / 1000)),
+                            ],
+                        );
                         return;
                     }
                 }
@@ -300,7 +325,11 @@ impl Node {
                 }
                 // Proactive reconnect with configurable backoff — the link was healthy,
                 // we're cycling the BLE channel to get fresh L2CAP credits.
-                let proactive_backoff_ms = self.config.transports.ble.iter()
+                let proactive_backoff_ms = self
+                    .config
+                    .transports
+                    .ble
+                    .iter()
                     .find_map(|(_, cfg)| {
                         let secs = cfg.proactive_reconnect_backoff_secs();
                         Some(secs * 1000)
@@ -741,9 +770,14 @@ impl Node {
             .unwrap_or(0);
 
         for addr in &dead_peers {
-            ble_log("link_dead", &self.peer_display_name(addr), &[
-                ("timeout_secs", &self.config.node.link_dead_timeout_secs.to_string()),
-            ]);
+            ble_log(
+                "link_dead",
+                &self.peer_display_name(addr),
+                &[(
+                    "timeout_secs",
+                    &self.config.node.link_dead_timeout_secs.to_string(),
+                )],
+            );
             warn!(
                 peer = %self.peer_display_name(addr),
                 timeout_secs = self.config.node.link_dead_timeout_secs,

--- a/src/node/handlers/rekey.rs
+++ b/src/node/handlers/rekey.rs
@@ -297,7 +297,10 @@ impl Node {
             };
 
             let sent = if let Some(transport) = self.transports.get(&transport_id) {
-                transport.send_urgent(&remote_addr, &msg1_bytes).await.is_ok()
+                transport
+                    .send_urgent(&remote_addr, &msg1_bytes)
+                    .await
+                    .is_ok()
             } else {
                 false
             };

--- a/src/node/handlers/rx_loop.rs
+++ b/src/node/handlers/rx_loop.rs
@@ -165,7 +165,7 @@ impl Node {
                             let body = &payload[1..];
                             let _ = self.api_send_benchmark_message(&peer, msg_type, body).await;
                         }
-                        if let Some((peer, payload)) = self.benchmark_mut().poll_throughput_sends() {
+                        for (peer, payload) in self.benchmark_mut().poll_throughput_sends() {
                             let msg_type = payload[0];
                             let body = &payload[1..];
                             let _ = self.api_send_benchmark_message(&peer, msg_type, body).await;

--- a/src/node/handlers/rx_loop.rs
+++ b/src/node/handlers/rx_loop.rs
@@ -67,6 +67,8 @@ impl Node {
         let mut tick =
             tokio::time::interval(Duration::from_secs(self.config.node.tick_interval_secs));
 
+        let mut benchmark_echo_tick = tokio::time::interval(Duration::from_millis(100));
+
         // Set up control socket channel
         let (control_tx, mut control_rx) =
             tokio::sync::mpsc::channel::<crate::control::ControlMessage>(32);
@@ -154,6 +156,14 @@ impl Node {
                     self.check_pending_lookups(now_ms).await;
                     self.poll_transport_discovery().await;
                     self.sample_transport_congestion();
+                }
+                _ = benchmark_echo_tick.tick() => {
+                    #[cfg(feature = "benchmark")]
+                    if let Some((peer, payload)) = self.benchmark_mut().poll_echo_sends() {
+                        let msg_type = payload[0];
+                        let body = &payload[1..];
+                        let _ = self.api_send_benchmark_message(&peer, msg_type, body).await;
+                    }
                 }
             }
         }

--- a/src/node/handlers/rx_loop.rs
+++ b/src/node/handlers/rx_loop.rs
@@ -67,7 +67,7 @@ impl Node {
         let mut tick =
             tokio::time::interval(Duration::from_secs(self.config.node.tick_interval_secs));
 
-        let mut benchmark_tick = tokio::time::interval(Duration::from_millis(10));
+        let mut benchmark_tick = tokio::time::interval(Duration::from_millis(25));
 
         // Set up control socket channel
         let (control_tx, mut control_rx) =

--- a/src/node/handlers/rx_loop.rs
+++ b/src/node/handlers/rx_loop.rs
@@ -159,10 +159,17 @@ impl Node {
                 }
                 _ = benchmark_echo_tick.tick() => {
                     #[cfg(feature = "benchmark")]
-                    if let Some((peer, payload)) = self.benchmark_mut().poll_echo_sends() {
-                        let msg_type = payload[0];
-                        let body = &payload[1..];
-                        let _ = self.api_send_benchmark_message(&peer, msg_type, body).await;
+                    {
+                        if let Some((peer, payload)) = self.benchmark_mut().poll_echo_sends() {
+                            let msg_type = payload[0];
+                            let body = &payload[1..];
+                            let _ = self.api_send_benchmark_message(&peer, msg_type, body).await;
+                        }
+                        if let Some((peer, payload)) = self.benchmark_mut().poll_throughput_sends() {
+                            let msg_type = payload[0];
+                            let body = &payload[1..];
+                            let _ = self.api_send_benchmark_message(&peer, msg_type, body).await;
+                        }
                     }
                 }
             }

--- a/src/node/handlers/rx_loop.rs
+++ b/src/node/handlers/rx_loop.rs
@@ -67,7 +67,7 @@ impl Node {
         let mut tick =
             tokio::time::interval(Duration::from_secs(self.config.node.tick_interval_secs));
 
-        let mut benchmark_echo_tick = tokio::time::interval(Duration::from_millis(100));
+        let mut benchmark_tick = tokio::time::interval(Duration::from_millis(10));
 
         // Set up control socket channel
         let (control_tx, mut control_rx) =
@@ -157,7 +157,7 @@ impl Node {
                     self.poll_transport_discovery().await;
                     self.sample_transport_congestion();
                 }
-                _ = benchmark_echo_tick.tick() => {
+                _ = benchmark_tick.tick() => {
                     #[cfg(feature = "benchmark")]
                     {
                         if let Some((peer, payload)) = self.benchmark_mut().poll_echo_sends() {

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -512,6 +512,10 @@ pub struct Node {
     /// Static hostname → npub mapping for DNS resolution.
     /// Built at construction from peer aliases and /etc/fips/hosts.
     host_map: Arc<HostMap>,
+
+    // === Benchmark ===
+    #[cfg(feature = "benchmark")]
+    benchmark: crate::benchmark::BenchmarkManager,
 }
 
 impl Node {
@@ -658,6 +662,8 @@ impl Node {
             host_map,
             path_mtu_lookup: Arc::new(std::sync::RwLock::new(HashMap::new())),
             discovered_peer_configs: HashMap::new(),
+            #[cfg(feature = "benchmark")]
+            benchmark: crate::benchmark::BenchmarkManager::new(),
         })
     }
 
@@ -794,6 +800,8 @@ impl Node {
             host_map,
             path_mtu_lookup: Arc::new(std::sync::RwLock::new(HashMap::new())),
             discovered_peer_configs: HashMap::new(),
+            #[cfg(feature = "benchmark")]
+            benchmark: crate::benchmark::BenchmarkManager::new(),
         })
     }
 
@@ -1381,6 +1389,11 @@ impl Node {
     /// Get the stats history collector.
     pub fn stats_history(&self) -> &stats_history::StatsHistory {
         &self.stats_history
+    }
+
+    #[cfg(feature = "benchmark")]
+    pub fn benchmark_mut(&mut self) -> &mut crate::benchmark::BenchmarkManager {
+        &mut self.benchmark
     }
 
     /// Sample the current node state into the stats history ring.

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -593,21 +593,21 @@ impl Node {
             startup_epoch,
             started_at: std::time::Instant::now(),
             config,
-             state: NodeState::Created,
-             is_leaf_only,
-             tree_state,
-             bloom_state,
-             coord_cache,
-             recent_requests: HashMap::new(),
-             transports: HashMap::new(),
-             transport_drops: HashMap::new(),
-             links: HashMap::new(),
-             addr_to_link: HashMap::new(),
-             packet_tx: None,
-             packet_rx: None,
-             disconnect_rx: None,
-             tun_max_mss: None,
-             ble_congested: Vec::new(),
+            state: NodeState::Created,
+            is_leaf_only,
+            tree_state,
+            bloom_state,
+            coord_cache,
+            recent_requests: HashMap::new(),
+            transports: HashMap::new(),
+            transport_drops: HashMap::new(),
+            links: HashMap::new(),
+            addr_to_link: HashMap::new(),
+            packet_tx: None,
+            packet_rx: None,
+            disconnect_rx: None,
+            tun_max_mss: None,
+            ble_congested: Vec::new(),
             connections: HashMap::new(),
             peers: HashMap::new(),
             sessions: HashMap::new(),
@@ -733,21 +733,21 @@ impl Node {
             startup_epoch,
             started_at: std::time::Instant::now(),
             config,
-             state: NodeState::Created,
-             is_leaf_only: false,
-             tree_state,
-             bloom_state,
-             coord_cache,
-             recent_requests: HashMap::new(),
-             transports: HashMap::new(),
-             transport_drops: HashMap::new(),
-             links: HashMap::new(),
-             addr_to_link: HashMap::new(),
-             packet_tx: None,
-             packet_rx: None,
-             disconnect_rx: None,
-             tun_max_mss: None,
-             ble_congested: Vec::new(),
+            state: NodeState::Created,
+            is_leaf_only: false,
+            tree_state,
+            bloom_state,
+            coord_cache,
+            recent_requests: HashMap::new(),
+            transports: HashMap::new(),
+            transport_drops: HashMap::new(),
+            links: HashMap::new(),
+            addr_to_link: HashMap::new(),
+            packet_tx: None,
+            packet_rx: None,
+            disconnect_rx: None,
+            tun_max_mss: None,
+            ble_congested: Vec::new(),
             connections: HashMap::new(),
             peers: HashMap::new(),
             sessions: HashMap::new(),
@@ -985,7 +985,6 @@ impl Node {
                     }
                 }
             }
-
         }
 
         // Warn when BLE is configured in fips.yaml but this build lacks BLE
@@ -1415,7 +1414,8 @@ impl Node {
     ) -> Result<(), NodeError> {
         let mut plaintext = vec![msg_type];
         plaintext.extend_from_slice(payload);
-        self.send_encrypted_link_message(node_addr, &plaintext).await
+        self.send_encrypted_link_message(node_addr, &plaintext)
+            .await
     }
 
     /// Sample the current node state into the stats history ring.

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1396,6 +1396,28 @@ impl Node {
         &mut self.benchmark
     }
 
+    #[cfg(feature = "benchmark")]
+    pub fn benchmark(&self) -> &crate::benchmark::BenchmarkManager {
+        &self.benchmark
+    }
+
+    /// Send a benchmark message to a peer over the encrypted link.
+    ///
+    /// Prepends the message type byte and delegates to
+    /// `send_encrypted_link_message`. Used by the control-socket
+    /// benchmark command handlers to fire echo/throughput frames.
+    #[cfg(feature = "benchmark")]
+    pub async fn api_send_benchmark_message(
+        &mut self,
+        node_addr: &NodeAddr,
+        msg_type: u8,
+        payload: &[u8],
+    ) -> Result<(), NodeError> {
+        let mut plaintext = vec![msg_type];
+        plaintext.extend_from_slice(payload);
+        self.send_encrypted_link_message(node_addr, &plaintext).await
+    }
+
     /// Sample the current node state into the stats history ring.
     /// Called once per tick from the RX loop.
     pub(crate) fn record_stats_history(&mut self) {

--- a/src/node/retry.rs
+++ b/src/node/retry.rs
@@ -79,7 +79,12 @@ impl RetryState {
     /// Note: For proactive reconnects (H13), this compounds with any previous
     /// failure reconnects since retry_count is preserved. See issue #108 for
     /// the proposal to use a separate, lighter backoff for proactive reconnects.
-    pub fn backoff_ms(&self, base_interval_ms: u64, max_backoff_ms: u64, proactive_backoff_ms: u64) -> u64 {
+    pub fn backoff_ms(
+        &self,
+        base_interval_ms: u64,
+        max_backoff_ms: u64,
+        proactive_backoff_ms: u64,
+    ) -> u64 {
         if self.proactive {
             return proactive_backoff_ms;
         }
@@ -103,14 +108,11 @@ impl Node {
         transport_name: &str,
         transport_addr: &crate::transport::TransportAddr,
     ) {
-        let already_in_static_config = self
-            .config
-            .auto_connect_peers()
-            .any(|pc| {
-                PeerIdentity::from_npub(&pc.npub)
-                    .map(|id| *id.node_addr() == node_addr)
-                    .unwrap_or(false)
-            });
+        let already_in_static_config = self.config.auto_connect_peers().any(|pc| {
+            PeerIdentity::from_npub(&pc.npub)
+                .map(|id| *id.node_addr() == node_addr)
+                .unwrap_or(false)
+        });
 
         if already_in_static_config {
             return;
@@ -131,11 +133,7 @@ impl Node {
         self.discovered_peer_configs.insert(node_addr, peer_config);
 
         if self.discovered_peer_configs.len() > super::DISCOVERED_PEER_CONFIGS_MAX {
-            let oldest_key = self
-                .discovered_peer_configs
-                .keys()
-                .next()
-                .copied();
+            let oldest_key = self.discovered_peer_configs.keys().next().copied();
             if let Some(key) = oldest_key {
                 self.discovered_peer_configs.remove(&key);
             }
@@ -300,7 +298,12 @@ impl Node {
     /// Similar to schedule_reconnect but sets the `proactive` flag for lighter
     /// backoff. Used by H13 SRTT threshold reconnect — the link was healthy,
     /// we're cycling the BLE channel to get fresh L2CAP credits.
-    pub(super) fn schedule_proactive_reconnect(&mut self, node_addr: NodeAddr, now_ms: u64, proactive_backoff_ms: u64) {
+    pub(super) fn schedule_proactive_reconnect(
+        &mut self,
+        node_addr: NodeAddr,
+        now_ms: u64,
+        proactive_backoff_ms: u64,
+    ) {
         let peer_config = self
             .config
             .auto_connect_peers()

--- a/src/node/tests/unit.rs
+++ b/src/node/tests/unit.rs
@@ -592,7 +592,9 @@ fn test_promote_cleans_up_pending_outbound_to_same_peer() {
         .promote_connection(completing_link_id, peer_b_identity, completing_time_ms)
         .unwrap();
 
-    assert!(matches!(result, PromotionResult::Promoted { cancelled_links, .. } if cancelled_links.len() == 1 && cancelled_links[0] == pending_link_id));
+    assert!(
+        matches!(result, PromotionResult::Promoted { cancelled_links, .. } if cancelled_links.len() == 1 && cancelled_links[0] == pending_link_id)
+    );
 
     assert_eq!(
         node.connection_count(),
@@ -601,7 +603,8 @@ fn test_promote_cleans_up_pending_outbound_to_same_peer() {
     );
     assert_eq!(node.peer_count(), 1, "Promoted peer should exist");
     assert!(
-        !node.pending_outbound
+        !node
+            .pending_outbound
             .contains_key(&(transport_id, pending_index.as_u32())),
         "pending_outbound entry should be removed immediately"
     );

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -351,7 +351,10 @@ mod tests {
     fn test_promotion_result_promoted() {
         let identity = make_peer_identity();
         let node_addr = *identity.node_addr();
-        let result = PromotionResult::Promoted { node_addr, cancelled_links: vec![] };
+        let result = PromotionResult::Promoted {
+            node_addr,
+            cancelled_links: vec![],
+        };
 
         assert!(result.node_addr().is_some());
         assert_eq!(result.node_addr(), Some(node_addr));

--- a/src/peer_policy.rs
+++ b/src/peer_policy.rs
@@ -32,9 +32,7 @@ impl PeerPolicy {
     // Ported from microfips
     pub fn check_frame_rate(&mut self) -> bool {
         let now = Instant::now();
-        let elapsed_ms = now
-            .duration_since(self.frame_window_start)
-            .as_millis() as u64;
+        let elapsed_ms = now.duration_since(self.frame_window_start).as_millis() as u64;
 
         if elapsed_ms >= FRAME_RATE_WINDOW_MS {
             self.frame_window_start = now;

--- a/src/peer_policy.rs
+++ b/src/peer_policy.rs
@@ -1,0 +1,59 @@
+// Ported from microfips: crates/microfips-protocol/src/peer_policy.rs
+// Only frame rate limiting logic is included.
+
+use std::time::Instant;
+
+/// Sliding window duration for frame rate limiting (1 second).
+pub const FRAME_RATE_WINDOW_MS: u64 = 1_000;
+
+/// Maximum frames allowed within one window.
+pub const FRAME_RATE_MAX: u16 = 100;
+
+/// Simplified peer policy containing only frame rate limiting.
+pub struct PeerPolicy {
+    frame_count: u16,
+    frame_window_start: Instant,
+}
+
+impl PeerPolicy {
+    pub fn new() -> Self {
+        let now = Instant::now();
+        Self {
+            frame_count: 0,
+            frame_window_start: now,
+        }
+    }
+
+    /// Check if a new frame is allowed under the rate limit.
+    ///
+    /// Uses a sliding window of `FRAME_RATE_WINDOW_MS` milliseconds.
+    /// At most `FRAME_RATE_MAX` frames are allowed per window.
+    /// Returns `true` if the frame is allowed, `false` if rate-limited.
+    // Ported from microfips
+    pub fn check_frame_rate(&mut self) -> bool {
+        let now = Instant::now();
+        let elapsed_ms = now
+            .duration_since(self.frame_window_start)
+            .as_millis() as u64;
+
+        if elapsed_ms >= FRAME_RATE_WINDOW_MS {
+            self.frame_window_start = now;
+            self.frame_count = 0;
+        }
+
+        if self.frame_count >= FRAME_RATE_MAX {
+            self.frame_window_start = now;
+            self.frame_count = 0;
+            return false;
+        }
+
+        self.frame_count = self.frame_count.saturating_add(1);
+        true
+    }
+}
+
+impl Default for PeerPolicy {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/transport/ble/capabilities.rs
+++ b/src/transport/ble/capabilities.rs
@@ -50,10 +50,7 @@ impl PeerCapabilities {
     /// throughput — the direct NSOutputStream write path is ~2.75× faster).
     pub fn macos_default() -> Self {
         Self(
-            Self::L2CAP_SUPPORTED
-                | Self::CAN_CENTRAL
-                | Self::CAN_PERIPHERAL
-                | Self::GATT_SUPPORTED,
+            Self::L2CAP_SUPPORTED | Self::CAN_CENTRAL | Self::CAN_PERIPHERAL | Self::GATT_SUPPORTED,
         )
     }
 

--- a/src/transport/ble/event_log.rs
+++ b/src/transport/ble/event_log.rs
@@ -106,11 +106,7 @@ fn days_to_ymd(mut days: i64) -> (i64, u8, u8) {
         (days - 146096) / 146097
     };
     let mut doe = days - era * 146097; // day of era [0, 146096]
-    let yoe = (doe
-        - doe / 1460
-        + doe / 36524
-        - doe / 146096)
-        / 365; // year of era [0, 399]
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365; // year of era [0, 399]
     let mut y = yoe + era * 400;
     doe -= yoe * 365 + yoe / 4 - yoe / 100;
     let mp = (doe * 10 + 5) / 306; // month [0-based from March]

--- a/src/transport/ble/io.rs
+++ b/src/transport/ble/io.rs
@@ -194,26 +194,42 @@ pub(super) const FIPS_GATT_PSM_CHAR_UUID_RAW: u128 = 0x250c_88dd_3dff_4c41_83b2_
 pub(super) const BLE_DEFAULT_QUEUE_DEPTH: usize = 32;
 
 /// Timeout for GATT PSM discovery operations.
-pub(super) const GATT_PSM_DISCOVER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+pub(super) const GATT_PSM_DISCOVER_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(10);
 
 /// Error message helpers for GATT PSM discovery (shared across platforms).
 pub(super) mod gatt_err {
     use super::super::addr::BleAddr;
 
     pub fn enum_services(addr: &BleAddr, e: &(impl std::fmt::Display + ?Sized)) -> String {
-        format!("discover_gatt_psm: failed to enumerate services for {}: {}", addr, e)
+        format!(
+            "discover_gatt_psm: failed to enumerate services for {}: {}",
+            addr, e
+        )
     }
     pub fn service_not_found(addr: &BleAddr) -> String {
-        format!("discover_gatt_psm: FIPS GATT PSM service not found on {}", addr)
+        format!(
+            "discover_gatt_psm: FIPS GATT PSM service not found on {}",
+            addr
+        )
     }
     pub fn enum_chars(addr: &BleAddr, e: &(impl std::fmt::Display + ?Sized)) -> String {
-        format!("discover_gatt_psm: failed to enumerate characteristics for {}: {}", addr, e)
+        format!(
+            "discover_gatt_psm: failed to enumerate characteristics for {}: {}",
+            addr, e
+        )
     }
     pub fn char_not_found(addr: &BleAddr) -> String {
-        format!("discover_gatt_psm: PSM characteristic not found on {}", addr)
+        format!(
+            "discover_gatt_psm: PSM characteristic not found on {}",
+            addr
+        )
     }
     pub fn read_psm(addr: &BleAddr, e: &(impl std::fmt::Display + ?Sized)) -> String {
-        format!("discover_gatt_psm: failed to read PSM characteristic on {}: {}", addr, e)
+        format!(
+            "discover_gatt_psm: failed to read PSM characteristic on {}: {}",
+            addr, e
+        )
     }
     pub fn timeout(addr: &BleAddr) -> String {
         format!("discover_gatt_psm: timed out discovering PSM for {}", addr)
@@ -250,6 +266,7 @@ mod bluer_impl {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
 
+    use crate::transport::ble::rate_limit::SendRateLimiter;
     use bluer::Address;
     use bluer::l2cap::{FlowControl, SeqPacket, SeqPacketListener, Socket, SocketAddr};
     use bluer::{
@@ -260,7 +277,6 @@ mod bluer_impl {
     use std::pin::Pin;
     use tokio::sync::Mutex;
     use tokio::time::{Duration, timeout};
-    use crate::transport::ble::rate_limit::SendRateLimiter;
     use tracing::{debug, trace, warn};
 
     pub(super) const FIPS_SERVICE_UUID: bluer::Uuid = bluer::Uuid::from_u128(FIPS_SERVICE_UUID_RAW);
@@ -337,12 +353,11 @@ mod bluer_impl {
                 }
             }
 
-            let rate_limiter: Option<
-                Arc<Mutex<SendRateLimiter>>,
-            > = if send_rate_bps > 0 {
-                Some(Arc::new(tokio::sync::Mutex::new(
-                    SendRateLimiter::new(send_rate_bps, send_burst_bytes),
-                )))
+            let rate_limiter: Option<Arc<Mutex<SendRateLimiter>>> = if send_rate_bps > 0 {
+                Some(Arc::new(tokio::sync::Mutex::new(SendRateLimiter::new(
+                    send_rate_bps,
+                    send_burst_bytes,
+                ))))
             } else {
                 None
             };
@@ -473,7 +488,8 @@ mod bluer_impl {
 
                 let mut chunk = vec![0u8; self.recv_mtu as usize];
                 let n = {
-                    self.conn.recv(&mut chunk)
+                    self.conn
+                        .recv(&mut chunk)
                         .await
                         .map_err(|e| TransportError::RecvFailed(format!("{}", e)))?
                 };
@@ -762,11 +778,7 @@ mod bluer_impl {
 
             timeout(GATT_PSM_DISCOVER_TIMEOUT, discover)
                 .await
-                .map_err(|_| {
-                    TransportError::Io(std::io::Error::other(
-                        gatt_err::timeout(addr),
-                    ))
-                })?
+                .map_err(|_| TransportError::Io(std::io::Error::other(gatt_err::timeout(addr))))?
         }
 
         async fn read_psm_from_gatt(
@@ -793,9 +805,7 @@ mod bluer_impl {
             addr: &BleAddr,
         ) -> Result<u16, TransportError> {
             let services = device.services().await.map_err(|e| {
-                TransportError::Io(std::io::Error::other(
-                    gatt_err::enum_services(addr, &e),
-                ))
+                TransportError::Io(std::io::Error::other(gatt_err::enum_services(addr, &e)))
             })?;
 
             debug!(remote_addr = %addr, count = services.len(), "GATT PSM discovery: enumerated services");
@@ -811,9 +821,7 @@ mod bluer_impl {
             };
 
             let characteristics = psm_service.characteristics().await.map_err(|e| {
-                TransportError::Io(std::io::Error::other(
-                    gatt_err::enum_chars(addr, &e),
-                ))
+                TransportError::Io(std::io::Error::other(gatt_err::enum_chars(addr, &e)))
             })?;
 
             let psm_char = find_char_by_uuid(&characteristics, FIPS_GATT_PSM_CHAR_UUID).await;
@@ -827,9 +835,7 @@ mod bluer_impl {
             };
 
             let value = psm_char.read().await.map_err(|e| {
-                TransportError::Io(std::io::Error::other(
-                    gatt_err::read_psm(addr, &e),
-                ))
+                TransportError::Io(std::io::Error::other(gatt_err::read_psm(addr, &e)))
             })?;
 
             let psm = parse_psm_value(&value, addr)?;
@@ -1249,7 +1255,13 @@ mod bluer_impl {
     }
 
     /// Run `sudo hcitool lecup` to refresh BLE connection parameters.
-    async fn run_lecup(handle: u16, min: u16, max: u16, latency: u16, timeout: u16) -> Result<(), String> {
+    async fn run_lecup(
+        handle: u16,
+        min: u16,
+        max: u16,
+        latency: u16,
+        timeout: u16,
+    ) -> Result<(), String> {
         let output = tokio::process::Command::new("sudo")
             .args([
                 "hcitool",
@@ -1270,7 +1282,8 @@ mod bluer_impl {
             let stderr = String::from_utf8_lossy(&output.stderr);
             Err(format!(
                 "sudo hcitool lecup exited with {}: {}",
-                output.status, stderr.trim()
+                output.status,
+                stderr.trim()
             ))
         }
     }
@@ -1318,7 +1331,15 @@ mod bluer_impl {
                 );
 
                 let addr_str = ble_addr.to_string_repr();
-                match run_lecup(handle, min_interval, max_interval, latency, supervision_timeout).await {
+                match run_lecup(
+                    handle,
+                    min_interval,
+                    max_interval,
+                    latency,
+                    supervision_timeout,
+                )
+                .await
+                {
                     Ok(()) => {
                         crate::transport::ble::event_log::log(
                             "ble_conn_param_refresh",
@@ -1347,10 +1368,7 @@ mod bluer_impl {
                         crate::transport::ble::event_log::log(
                             "ble_conn_param_refresh_failed",
                             &addr_str,
-                            &[
-                                ("handle", &format!("0x{:04X}", handle)),
-                                ("error", &e),
-                            ],
+                            &[("handle", &format!("0x{:04X}", handle)), ("error", &e)],
                         );
                     }
                 }
@@ -1361,7 +1379,7 @@ mod bluer_impl {
 
 #[cfg(bluer_available)]
 pub use bluer_impl::{
-    spawn_conn_param_refresh_loop, BluerAcceptor, BluerIo, BluerScanner, BluerStream,
+    BluerAcceptor, BluerIo, BluerScanner, BluerStream, spawn_conn_param_refresh_loop,
 };
 
 // ============================================================================

--- a/src/transport/ble/io_macos.rs
+++ b/src/transport/ble/io_macos.rs
@@ -1,10 +1,10 @@
 //! macOS BLE I/O via bluest (central role) and objc2-core-bluetooth (peripheral role).
 
 use super::{
-    BLE_DEFAULT_QUEUE_DEPTH, frame_payload, parse_psm_value, try_take_framed_payload,
-    gatt_err, BleAcceptor, BleIo, BleScanner, BleStream, FIPS_GATT_PSM_CHAR_UUID_RAW,
-    FIPS_GATT_PSM_SERVICE_UUID_RAW, FIPS_SERVICE_UUID_RAW, GATT_PSM_DISCOVER_TIMEOUT,
-    TransportError,
+    BLE_DEFAULT_QUEUE_DEPTH, BleAcceptor, BleIo, BleScanner, BleStream,
+    FIPS_GATT_PSM_CHAR_UUID_RAW, FIPS_GATT_PSM_SERVICE_UUID_RAW, FIPS_SERVICE_UUID_RAW,
+    GATT_PSM_DISCOVER_TIMEOUT, TransportError, frame_payload, gatt_err, parse_psm_value,
+    try_take_framed_payload,
 };
 use crate::transport::ble::Unpoison;
 use crate::transport::ble::addr::BleAddr;
@@ -746,10 +746,12 @@ impl PeripheralStream {
         send_rate_bps: u64,
         send_burst_bytes: u32,
     ) -> Result<Self, TransportError> {
-        let input_stream = unsafe { channel.0.inputStream() }
-            .ok_or_else(|| TransportError::Io(std::io::Error::other("CBL2CAPChannel has no input stream")))?;
-        let output_stream = unsafe { channel.0.outputStream() }
-            .ok_or_else(|| TransportError::Io(std::io::Error::other("CBL2CAPChannel has no output stream")))?;
+        let input_stream = unsafe { channel.0.inputStream() }.ok_or_else(|| {
+            TransportError::Io(std::io::Error::other("CBL2CAPChannel has no input stream"))
+        })?;
+        let output_stream = unsafe { channel.0.outputStream() }.ok_or_else(|| {
+            TransportError::Io(std::io::Error::other("CBL2CAPChannel has no output stream"))
+        })?;
 
         let read_notify = Arc::new(tokio::sync::Notify::new());
         let input_delegate = PeripheralInputDelegate::new(read_notify.clone());
@@ -1181,7 +1183,7 @@ define_class!(
                         return;
                     }
                 };
-                 if let Ok(mut pending) = self.ivars().pending_streams.lock() {
+                if let Ok(mut pending) = self.ivars().pending_streams.lock() {
                     pending.push(SendablePeripheralStream(stream));
                 }
                 let _ = self
@@ -1400,9 +1402,7 @@ impl BluestIo {
                 .discover_services_with_uuid(FIPS_GATT_PSM_SERVICE_UUID)
                 .await
                 .map_err(|e| {
-                    TransportError::Io(std::io::Error::other(
-                        gatt_err::enum_services(addr, &e),
-                    ))
+                    TransportError::Io(std::io::Error::other(gatt_err::enum_services(addr, &e)))
                 })?;
 
             debug!(remote_addr = %addr, count = services.len(), "GATT PSM discovery: enumerated services");
@@ -1420,9 +1420,7 @@ impl BluestIo {
             };
 
             let characteristics = psm_service.characteristics().await.map_err(|e| {
-                TransportError::Io(std::io::Error::other(
-                    gatt_err::enum_chars(addr, &e),
-                ))
+                TransportError::Io(std::io::Error::other(gatt_err::enum_chars(addr, &e)))
             })?;
 
             let psm_char = characteristics
@@ -1438,9 +1436,7 @@ impl BluestIo {
             };
 
             let value = psm_char.read().await.map_err(|e| {
-                TransportError::Io(std::io::Error::other(
-                    gatt_err::read_psm(addr, &e),
-                ))
+                TransportError::Io(std::io::Error::other(gatt_err::read_psm(addr, &e)))
             })?;
 
             let psm = parse_psm_value(&value, addr)?;
@@ -1452,11 +1448,7 @@ impl BluestIo {
 
         tokio::time::timeout(GATT_PSM_DISCOVER_TIMEOUT, discover)
             .await
-            .map_err(|_| {
-                TransportError::Io(std::io::Error::other(
-                    gatt_err::timeout(addr),
-                ))
-            })?
+            .map_err(|_| TransportError::Io(std::io::Error::other(gatt_err::timeout(addr))))?
     }
 }
 

--- a/src/transport/ble/mod.rs
+++ b/src/transport/ble/mod.rs
@@ -402,7 +402,11 @@ impl<I: BleIo> BleTransport<I> {
                     debug!(transport_id = %self.transport_id, remote_addr = %addr, "BLE send dropped (congested), packet discarded");
                     return Err(e);
                 }
-                event_log::log("ble_send_failed", &addr.to_string(), &[("error", &format!("{e}"))]);
+                event_log::log(
+                    "ble_send_failed",
+                    &addr.to_string(),
+                    &[("error", &format!("{e}"))],
+                );
                 let mut pool = self.pool.lock().await;
                 pool.remove(addr);
                 if let Some(tx) = &self.disconnect_tx {
@@ -578,7 +582,10 @@ impl<I: BleIo> BleTransport<I> {
                                     debug!(transport_id = %transport_id, remote_addr = %addr_clone, "BLE outbound pubkey exchange complete");
                                     discovery_buffer
                                         .add_peer_with_pubkey(&ble_addr, result.peer_pubkey);
-                                    known_peer_capabilities.lock().await.insert(ble_addr.clone(), result.peer_capabilities);
+                                    known_peer_capabilities
+                                        .lock()
+                                        .await
+                                        .insert(ble_addr.clone(), result.peer_capabilities);
                                 }
                                 Err(e) => {
                                     warn!(transport_id = %transport_id, remote_addr = %addr_clone, error = %e, "BLE outbound pubkey exchange failed");
@@ -594,10 +601,14 @@ impl<I: BleIo> BleTransport<I> {
 
                         let send_mtu = stream.send_mtu();
                         let recv_mtu = stream.recv_mtu();
-                        event_log::log("ble_outbound", &addr_clone.to_string(), &[
-                            ("send_mtu", &send_mtu.to_string()),
-                            ("recv_mtu", &recv_mtu.to_string()),
-                        ]);
+                        event_log::log(
+                            "ble_outbound",
+                            &addr_clone.to_string(),
+                            &[
+                                ("send_mtu", &send_mtu.to_string()),
+                                ("recv_mtu", &recv_mtu.to_string()),
+                            ],
+                        );
                         let stream = Arc::new(stream);
 
                         let recv_task = tokio::spawn(receive_loop(
@@ -978,10 +989,14 @@ async fn accept_loop<A, I: BleIo>(
                 let send_mtu = stream.send_mtu();
                 let recv_mtu = stream.recv_mtu();
 
-                event_log::log("ble_inbound", &ta.to_string(), &[
-                    ("send_mtu", &send_mtu.to_string()),
-                    ("recv_mtu", &recv_mtu.to_string()),
-                ]);
+                event_log::log(
+                    "ble_inbound",
+                    &ta.to_string(),
+                    &[
+                        ("send_mtu", &send_mtu.to_string()),
+                        ("recv_mtu", &recv_mtu.to_string()),
+                    ],
+                );
 
                 if let Some(ref our_pubkey) = local_pubkey {
                     wait_before_outbound_pubkey_exchange().await;
@@ -992,7 +1007,10 @@ async fn accept_loop<A, I: BleIo>(
                                 discovery_buffer.add_peer_with_pubkey(&addr, result.peer_pubkey);
 
                                 let peer_capabilities = result.peer_capabilities;
-                                known_peer_capabilities.lock().await.insert(addr.clone(), peer_capabilities);
+                                known_peer_capabilities
+                                    .lock()
+                                    .await
+                                    .insert(addr.clone(), peer_capabilities);
                                 if !peer_capabilities.can_accept_inbound() {
                                     debug!(transport_id = %transport_id, remote_addr = %ta, "BLE inbound: peer is central-only, accepting inbound connection anyway");
                                 } else if peer_capabilities.prefers_outbound()
@@ -1170,11 +1188,15 @@ async fn receive_loop<S: BleStream>(
             )
         });
 
-    event_log::log("ble_connect", &args.addr.to_string(), &[
-        ("transport_id", &args.transport_id.to_string()),
-        ("recv_timeout_secs", &args.recv_timeout_secs.to_string()),
-        ("recv_mtu", &args.recv_mtu.to_string()),
-    ]);
+    event_log::log(
+        "ble_connect",
+        &args.addr.to_string(),
+        &[
+            ("transport_id", &args.transport_id.to_string()),
+            ("recv_timeout_secs", &args.recv_timeout_secs.to_string()),
+            ("recv_mtu", &args.recv_mtu.to_string()),
+        ],
+    );
 
     loop {
         let recv_result = tokio::time::timeout(
@@ -1186,10 +1208,14 @@ async fn receive_loop<S: BleStream>(
         match recv_result {
             Ok(Ok(0)) => {
                 let elapsed = start.elapsed();
-                event_log::log("ble_disconnect", &args.addr.to_string(), &[
-                    ("reason", "closed_by_peer"),
-                    ("uptime_secs", &format!("{:.1}", elapsed.as_secs_f32())),
-                ]);
+                event_log::log(
+                    "ble_disconnect",
+                    &args.addr.to_string(),
+                    &[
+                        ("reason", "closed_by_peer"),
+                        ("uptime_secs", &format!("{:.1}", elapsed.as_secs_f32())),
+                    ],
+                );
                 info!(transport_id = %args.transport_id, remote_addr = %args.addr, elapsed_secs = elapsed.as_secs_f32(), "BLE connection closed by peer");
                 break;
             }
@@ -1211,12 +1237,16 @@ async fn receive_loop<S: BleStream>(
                     continue;
                 }
                 let uptime = start.elapsed();
-                event_log::log("ble_disconnect", &args.addr.to_string(), &[
-                    ("reason", "recv_error"),
-                    ("error", &err_str),
-                    ("consecutive_errors", &consecutive_errors.to_string()),
-                    ("uptime_secs", &format!("{:.1}", uptime.as_secs_f32())),
-                ]);
+                event_log::log(
+                    "ble_disconnect",
+                    &args.addr.to_string(),
+                    &[
+                        ("reason", "recv_error"),
+                        ("error", &err_str),
+                        ("consecutive_errors", &consecutive_errors.to_string()),
+                        ("uptime_secs", &format!("{:.1}", uptime.as_secs_f32())),
+                    ],
+                );
                 if consecutive_errors >= 3 {
                     warn!(transport_id = %args.transport_id, remote_addr = %args.addr, error = %e, consecutive = consecutive_errors, uptime_secs = uptime.as_secs_f32(), "BLE receive errors exceeded threshold");
                 } else {
@@ -1227,11 +1257,15 @@ async fn receive_loop<S: BleStream>(
             }
             Err(_) => {
                 let uptime = start.elapsed();
-                event_log::log("ble_disconnect", &args.addr.to_string(), &[
-                    ("reason", "recv_timeout"),
-                    ("timeout_secs", &args.recv_timeout_secs.to_string()),
-                    ("uptime_secs", &format!("{:.1}", uptime.as_secs_f32())),
-                ]);
+                event_log::log(
+                    "ble_disconnect",
+                    &args.addr.to_string(),
+                    &[
+                        ("reason", "recv_timeout"),
+                        ("timeout_secs", &args.recv_timeout_secs.to_string()),
+                        ("uptime_secs", &format!("{:.1}", uptime.as_secs_f32())),
+                    ],
+                );
                 warn!(transport_id = %args.transport_id, remote_addr = %args.addr, timeout_secs = args.recv_timeout_secs, uptime_secs = uptime.as_secs_f32(), "BLE recv timeout — link may be silently dead");
                 args.stats.record_recv_error();
                 break;
@@ -1504,7 +1538,10 @@ async fn scan_probe_loop<I: io::BleIo>(
                 debug!(transport_id = %transport_id, remote_addr = %addr, "BLE probe complete");
 
                 let peer_capabilities = result.peer_capabilities;
-                known_peer_capabilities.lock().await.insert(addr.clone(), peer_capabilities);
+                known_peer_capabilities
+                    .lock()
+                    .await
+                    .insert(addr.clone(), peer_capabilities);
                 if !peer_capabilities.can_accept_inbound() {
                     debug!(transport_id = %transport_id, remote_addr = %addr, "BLE probe: peer cannot accept inbound, yielding to peer's outbound");
                     buffer.add_peer_with_pubkey(&addr, result.peer_pubkey);
@@ -1537,39 +1574,39 @@ async fn scan_probe_loop<I: io::BleIo>(
                         backoff: Arc::clone(&backoff),
                         ble_addr: addr.clone(),
                         established_at: tokio::time::Instant::now(),
-                         on_cleanup: {
-                             let io = Arc::clone(&io);
-                             let pool = Arc::clone(&pool);
-                             let ble_addr = addr.clone();
-                             let ta_check = ta.clone();
-                             Some(Box::new(move || {
-                                 let io = Arc::clone(&io);
-                                 let pool = Arc::clone(&pool);
-                                 let ble_addr = ble_addr.clone();
-                                 let ta_check = ta_check.clone();
-                                 tokio::spawn(async move {
-                                     let pool_guard = pool.lock().await;
-                                     if pool_guard.contains(&ta_check) {
-                                         debug!(
-                                             remote_addr = %ble_addr,
-                                             "BLE on_cleanup: skipping disconnect_device, new connection exists in pool"
-                                         );
-                                         return;
-                                     }
-                                     drop(pool_guard);
-                                     io.disconnect_device(&ble_addr).await;
-                                 });
-                             }))
-                         },
-                         conn_param_refresh_secs,
-                         conn_param_min_interval,
-                         conn_param_max_interval,
-                         conn_param_latency,
-                         conn_param_timeout,
-                     },
-                 ));
+                        on_cleanup: {
+                            let io = Arc::clone(&io);
+                            let pool = Arc::clone(&pool);
+                            let ble_addr = addr.clone();
+                            let ta_check = ta.clone();
+                            Some(Box::new(move || {
+                                let io = Arc::clone(&io);
+                                let pool = Arc::clone(&pool);
+                                let ble_addr = ble_addr.clone();
+                                let ta_check = ta_check.clone();
+                                tokio::spawn(async move {
+                                    let pool_guard = pool.lock().await;
+                                    if pool_guard.contains(&ta_check) {
+                                        debug!(
+                                            remote_addr = %ble_addr,
+                                            "BLE on_cleanup: skipping disconnect_device, new connection exists in pool"
+                                        );
+                                        return;
+                                    }
+                                    drop(pool_guard);
+                                    io.disconnect_device(&ble_addr).await;
+                                });
+                            }))
+                        },
+                        conn_param_refresh_secs,
+                        conn_param_min_interval,
+                        conn_param_max_interval,
+                        conn_param_latency,
+                        conn_param_timeout,
+                    },
+                ));
 
-                 let conn = BleConnection {
+                let conn = BleConnection {
                     stream,
                     recv_task: Some(recv_task),
                     send_mtu,

--- a/src/transport/ble/rate_limit.rs
+++ b/src/transport/ble/rate_limit.rs
@@ -255,12 +255,16 @@ impl BleRateAdapter {
             // Log rate changes to the BLE event log for experiment correlation.
             // Each entry includes the SRTT sample that triggered the decision,
             // the old/new rates, and the decision name for filtering.
-            super::event_log::log("rate_adapter", "", &[
-                ("srtt_ms", &format!("{:.1}", srtt_ms)),
-                ("old_rate_bps", &old_rate.to_string()),
-                ("new_rate_bps", &self.current_rate_bps.to_string()),
-                ("decision", decision),
-            ]);
+            super::event_log::log(
+                "rate_adapter",
+                "",
+                &[
+                    ("srtt_ms", &format!("{:.1}", srtt_ms)),
+                    ("old_rate_bps", &old_rate.to_string()),
+                    ("new_rate_bps", &self.current_rate_bps.to_string()),
+                    ("decision", decision),
+                ],
+            );
         }
 
         self.current_rate_bps

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1159,8 +1159,8 @@ impl TransportHandle {
             TransportHandle::Udp(t) => t.close_connection(addr),
             #[cfg(unix)]
             TransportHandle::Ethernet(t) => t.close_connection(addr),
-            TransportHandle::Tcp(_) => {},
-            TransportHandle::Tor(_) => {},
+            TransportHandle::Tcp(_) => {}
+            TransportHandle::Tor(_) => {}
             #[cfg(any(all(target_os = "linux", bluer_available), feature = "ble-macos"))]
             TransportHandle::Ble(t) => t.close_connection(addr),
         }


### PR DESCRIPTION
## Summary

Benchmark protocol redesigned from scratch with feature-gated `benchmark` feature flag.

### Commits on this branch (8 total):

1. **`c160f37`** feat(benchmark): benchmark module with echo + throughput
2. **`5434410`** feat(benchmark): wire up echo send path
3. **`db5e0a2`** fix(benchmark): route echo fire command through start_echo_test
4. **`b7526a8`** fix(benchmark): sequential echo pings with 100ms pacing
5. **`5e10d6a`** fix(benchmark): reduce echo timeout to 2s, fix query pending ambiguity
6. **`864d049`** feat(benchmark): paced throughput stream sends
7. **`4c80138`** fix(benchmark): cap batch-drain to 2 frames to avoid BLE congestion
8. **`97e9020`** fix(benchmark): report initiator-side frames_sent for accurate loss
9. **`7898547`** perf(benchmark): reduce tick from 100ms to 10ms for accurate pacing
10. **`0eceb32`** perf(benchmark): use 25ms tick balancing throughput and BLE congestion
11. **`93ffb42`** feat(benchmark): add throughput responder with auto report generation
12. **`b16b658`** feat: port PeerPolicy frame rate limiting from microfips

### Hardware-Verified Results

**Echo (FIPS → ESP32, sequential pings):**
| Test | Pings | Loss | Median | P95 | Jitter |
|------|-------|------|--------|-----|--------|
| 50-ping | 50/50 | 0% | 31ms | 63ms | 6.7ms |
| 100-ping | 97/100 | 3% | 55ms | 100ms | 14.6ms |
| 20-ping (latest) | 20/20 | 0% | 51ms | 76ms | 12.1ms |

**Throughput (FIPS → ESP32, paced stream, 25ms tick):**
| Target Rate | Frame Size | Achieved | Loss | Efficiency |
|-------------|-----------|----------|------|------------|
| 20 kbps | 128B | 14.9 kbps | 29% | 75% |
| 40 kbps | 128B | 32.8 kbps | 22% | 82% |
| 60 kbps | 200B | 33.7 kbps | 45% | 56% |
| 80 kbps | 200B | 43.8 kbps | 47% | 55% |

**BLE L2CAP throughput ceiling: ~44 kbps (~5.5 KB/s)**

**Stability:**
- 60-min test: 1 disconnect (at min 29, auto-reconnected), 0% MMP loss, ETX 1.0
- 5-min regression: 0 disconnects, 0% MMP loss, ETX 1.0 (×3 runs)
- 3-min post-deploy: 0 disconnects, 0% MMP loss, ETX 1.0

### Features
- **Echo**: Sequential pings with per-ping RTT measurement, configurable count/payload
- **Throughput**: Paced stream sends, auto report from responder, initiator-side frames_sent tracking
- **PeerPolicy**: Frame rate limiting (100 frames/sec) ported from microfips
- **Feature-gated**: `--features benchmark` keeps benchmark code completely separate from core transport
- **Responder mode**: FIPS can now act as both benchmark initiator AND responder